### PR TITLE
fix: Renaming statistic tracking parameters

### DIFF
--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnection.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnection.java
@@ -54,7 +54,8 @@ public class FireboltConnection extends AbstractConnection {
 		this.fireboltAuthenticationService = fireboltAuthenticationService;
 		this.fireboltEngineService = fireboltEngineService;
 		this.loginProperties = this.extractFireboltProperties(url, connectionSettings);
-		loginProperties.getAdditionalProperties().remove("connector_versions");
+		loginProperties.getAdditionalProperties().remove("user_clients");
+		loginProperties.getAdditionalProperties().remove("user_drivers");
 		this.httpConnectionUrl = getHttpConnectionUrl(loginProperties);
 		this.fireboltStatementService = fireboltStatementService;
 		this.statements = new ArrayList<>();
@@ -66,8 +67,8 @@ public class FireboltConnection extends AbstractConnection {
 	public FireboltConnection(@NonNull String url, Properties connectionSettings) throws FireboltException {
 		ObjectMapper objectMapper = FireboltObjectMapper.getInstance();
 		this.loginProperties = this.extractFireboltProperties(url, connectionSettings);
-		String driverVersions = loginProperties.getAdditionalProperties().remove("driver_versions");
-		String clientVersions = loginProperties.getAdditionalProperties().remove("client_versions");
+		String driverVersions = loginProperties.getAdditionalProperties().remove("user_drivers");
+		String clientVersions = loginProperties.getAdditionalProperties().remove("user_clients");
 		this.httpConnectionUrl = getHttpConnectionUrl(loginProperties);
 		CloseableHttpClient httpClient = getHttpClient(loginProperties);
 		this.fireboltAuthenticationService = new FireboltAuthenticationService(

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionTest.java
@@ -168,7 +168,8 @@ class FireboltConnectionTest {
 	@Test
 	void shouldExtractConnectorOverrides() throws SQLException {
 		when(fireboltStatementService.execute(any(), any(), any())).thenReturn(new ByteArrayInputStream("".getBytes()));
-		connectionProperties.put("connector_versions", "ConnA:1.0.9,ConnB:2.8.0");
+		connectionProperties.put("user_clients", "ConnA:1.0.9,ConnB:2.8.0");
+		connectionProperties.put("user_drivers", "DriverA:2.0.9,DriverB:3.8.0");
 
 		FireboltConnection fireboltConnectionImpl = new FireboltConnection(URL, connectionProperties,
 				fireboltAuthenticationService, fireboltEngineService, fireboltStatementService);
@@ -177,8 +178,10 @@ class FireboltConnectionTest {
 		statement.execute();
 
 		verify(fireboltStatementService).execute(any(), propertiesArgumentCaptor.capture(), any());
-		assertNull(propertiesArgumentCaptor.getValue().getAdditionalProperties().get("connector_versions"));
-		assertNull(fireboltConnectionImpl.getSessionProperties().getAdditionalProperties().get("connector_versions"));
+		assertNull(propertiesArgumentCaptor.getValue().getAdditionalProperties().get("user_clients"));
+		assertNull(propertiesArgumentCaptor.getValue().getAdditionalProperties().get("user_drivers"));
+		assertNull(fireboltConnectionImpl.getSessionProperties().getAdditionalProperties().get("user_clients"));
+		assertNull(fireboltConnectionImpl.getSessionProperties().getAdditionalProperties().get("user_drivers"));
 	}
 
 	@Test


### PR DESCRIPTION
Getting naming in line with other connectors as per https://docs.google.com/document/d/1HOnfyG0UHFnkZAhnkxfpfgjjSDkZm2eXkOact2BVuYo