### PR TITLE
Handle edge case when year is 0000

### DIFF
--- a/src/main/java/com/firebolt/jdbc/type/date/SqlDateUtil.java
+++ b/src/main/java/com/firebolt/jdbc/type/date/SqlDateUtil.java
@@ -31,12 +31,17 @@ public class SqlDateUtil {
 	// calendar(1582-10-05T00:00:00Z) from the epoch of 1970-01-01T00:00:00Z
 	private static final long GREGORIAN_START_DATE_IN_MILLIS = -12220156800000L;
 
-	private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+	private static final DateTimeFormatter dateFormatter = new DateTimeFormatterBuilder()
+			.appendValue(ChronoField.YEAR, 4).parseDefaulting(ChronoField.YEAR, 0).appendPattern("[-]MM-dd")
+			.toFormatter();
 
 	public static final Function<Date, String> transformFromDateToSQLStringFunction = value -> String.format("'%s'",
 			dateFormatter.format(value.toLocalDate()));
-	DateTimeFormatter dateTimeFormatter = new DateTimeFormatterBuilder().appendPattern("yyyy-MM-dd [HH:mm[:ss]]")
-			.appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true).toFormatter();
+
+	public static final DateTimeFormatter dateTimeFormatter = new DateTimeFormatterBuilder()
+			.appendValue(ChronoField.YEAR, 4).parseDefaulting(ChronoField.YEAR, 0)
+			.appendPattern("[-]MM-dd [HH:mm[:ss]]").appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+			.toFormatter();
 	public static final BiFunction<String, TimeZone, Timestamp> transformToTimestampFunction = (value,
 			fromTimeZone) -> parse(value, fromTimeZone).map(t -> {
 				Timestamp ts = new Timestamp(getEpochMilli(t));

--- a/src/test/java/com/firebolt/jdbc/type/date/SqlDateUtilTest.java
+++ b/src/test/java/com/firebolt/jdbc/type/date/SqlDateUtilTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.TimeZone;
@@ -23,7 +25,7 @@ class SqlDateUtilTest {
 	void shouldTransformTimestampWithDefaultTzWhenTimeZoneIsNotSpecified() {
 		String timestamp = "1000-08-23 12:57:13.073456789";
 		ZonedDateTime zonedDateTime = ZonedDateTime.of(1000, 8, 23, 12, 57, 13, 73456789, UTC_TZ.toZoneId());
-		Timestamp expectedTimestamp = new Timestamp(zonedDateTime.toInstant().toEpochMilli() + ONE_DAY_MILLIS * 6 );
+		Timestamp expectedTimestamp = new Timestamp(zonedDateTime.toInstant().toEpochMilli() + ONE_DAY_MILLIS * 6);
 		expectedTimestamp.setNanos(73456789);
 		assertEquals(expectedTimestamp, SqlDateUtil.transformToTimestampFunction.apply(timestamp, null));
 	}
@@ -134,6 +136,21 @@ class SqlDateUtilTest {
 
 		ZonedDateTime zonedDateTime6 = ZonedDateTime.of(1099, 1, 29, 12, 57, 13, 73456789, UTC_TZ.toZoneId());
 		assertEquals(6, SqlDateUtil.calculateJulianToGregorianDiffMillis(zonedDateTime6) / ONE_DAY_MILLIS);
+	}
+
+	@Test
+	void shouldTransformDateWithZeroYear() {
+		String timeWithMissingMinutes = "0000-01-01";
+		Date date = Date.valueOf(LocalDate.of(0, 1, 1));
+		assertEquals(date,
+				SqlDateUtil.transformToDateFunction.apply(timeWithMissingMinutes, null));
+	}
+
+	@Test
+	void shouldTransformTimestampDateWithZeroYear() {
+		String timeWithMissingMinutes = "0000-01-01 12:13:14";
+		Timestamp ts = Timestamp.valueOf(LocalDateTime.of(0, 1, 1, 12, 13, 14));
+		assertEquals(ts, SqlDateUtil.transformToTimestampFunction.apply(timeWithMissingMinutes, null));
 	}
 
 }


### PR DESCRIPTION
There is an edge case where Firebolt would send a date with a year 0000. Such date do no exist (but we get it from the backend). The purpose of this PR is to simply handle such scenario (as it currently throws an exception).