### PR TITLE
Remove dependencies from pom.xml due to shading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,6 +171,11 @@ publishing {
     publications {
         maven(MavenPublication) {
             from components.java
+            // remove dependencies due to shaded jar
+            pom.withXml {
+              node = asNode()
+              node.remove(node.get('dependencies'))
+            }
         }
     }
 


### PR DESCRIPTION
When specifiying the jdbc as a dependency, the POM file states the existing dependencies, even though all of those are shaded, resulting in bigger packages. This commit removes all dependencies when the pom file is created.