### PR TITLE
Build: Exclude slf4j from shading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,9 +138,11 @@ shadowJar {
     packages.each {
         relocate(it, "com.firebolt.shadow.${it}")
     }
-    // while slf4j is not relocated, but should still not be shaded
-    exclude("org/slf4j/**")
-    exclude("META-INF/maven/org.slf4j/**")
+    if (!project.hasProperty("addLogbackDependency")) {
+        // while slf4j is not relocated, but should still not be shaded
+        exclude("org/slf4j/**")
+        exclude("META-INF/maven/org.slf4j/**")
+    }
     exclude("test/**")
     exclude("integrationTest/**")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -125,19 +125,22 @@ shadowJar {
     def packages = [] as Set<String>
     configurations.each { configuration ->
         configuration.files.each { jar ->
-            JarFile jf = new JarFile(jar)
-            jf.entries().each { entry ->
-                if (entry.name.endsWith(".class") && entry.name != "module-info.class" &&
-                   !entry.name.startsWith('org/slf4j') && !entry.name.startsWith('ch/qos/logback')) {
-                    packages << entry.name[0..entry.name.lastIndexOf('/')-1].replaceAll('/', '.')
+            try (JarFile jf = new JarFile(jar)) {
+                jf.entries().each { entry ->
+                    if (entry.name.endsWith(".class") && entry.name != "module-info.class" &&
+                       !entry.name.startsWith('org/slf4j') && !entry.name.startsWith('ch/qos/logback')) {
+                        packages << entry.name[0..entry.name.lastIndexOf('/')-1].replaceAll('/', '.')
+                    }
                 }
             }
-            jf.close()
         }
     }
     packages.each {
         relocate(it, "com.firebolt.shadow.${it}")
     }
+    // while slf4j is not relocated, but should still not be shaded
+    exclude("org/slf4j/**")
+    exclude("META-INF/maven/org.slf4j/**")
     exclude("test/**")
     exclude("integrationTest/**")
 }


### PR DESCRIPTION
If you take a look at the shaded jar, the log4j dependency is included, but not shaded.

Note: This makes #113 obsolete, as now the log4j dependency needs to be defined as a proper dependency, whereas that PR removes all dependencies.