### PR TITLE
[FIR-22970] alb keep alive when compress=1

### DIFF
--- a/src/main/java/com/firebolt/jdbc/resultset/compress/LZ4InputStream.java
+++ b/src/main/java/com/firebolt/jdbc/resultset/compress/LZ4InputStream.java
@@ -43,6 +43,7 @@ public class LZ4InputStream extends InputStream {
 
 	public static final int MAGIC = 0x82;
 	private static final LZ4Factory factory = LZ4Factory.fastestInstance();
+	private static final BlockChecksum keepalive = new BlockChecksum(0, 0);
 	private final InputStream stream;
 	private final DataInputStream dataWrapper;
 
@@ -159,6 +160,12 @@ public class LZ4InputStream extends InputStream {
 		// checksum - 16 bytes.
 		readFully(dataWrapper, checksum, 1, 15);
 		BlockChecksum expected = BlockChecksum.fromBytes(checksum);
+
+		// ALB keepalive
+		if (expected.equals(keepalive)) {
+			return new byte[]{0x20};
+		}
+
 		// header:
 		// 1 byte - 0x82 (shows this is LZ4)
 		int magic = dataWrapper.readUnsignedByte();

--- a/src/main/java/com/firebolt/jdbc/resultset/compress/LZ4InputStream.java
+++ b/src/main/java/com/firebolt/jdbc/resultset/compress/LZ4InputStream.java
@@ -163,7 +163,7 @@ public class LZ4InputStream extends InputStream {
 
 		// ALB keepalive
 		if (expected.equals(keepalive)) {
-			return new byte[]{0x20};
+			return new byte[]{0x20}; // space, same as uncompressed path
 		}
 
 		// header:


### PR DESCRIPTION
FIR-22970: alb keep alive when `compress=1`

## Summary:
Previously when `compress=1`, we can receive a stream like the following (decimal), if it takes >3500sec for packdb to output anything:
```
32, -4, 102, -104, 79, -114, 2, 31, 97, -74, 79, 44, -19, 55, 15, 82, 48, -126, 35, 0, 0, 0, 24, 0, 0, 0, -16, 9, 115, 108, 101, 101, 112, 69, 97, 99, 104, 82, 111, 119, 40, 49, 41, 10, 98, 111, 111, 108, 101, 97, 110, 10, 27, 96, 48, 68, 104, 64, 75, -51, 28, 106, 28, 18, 101, 1, -4, 23, -126, 20, 0, 0, 0, 20, 0, 0, 0, 41, 102, 10, 2, 0, 80, 10, 102, 10, 102, 10
```
There can be several 32 in the beginning (our alb keep alive empty byte), and 16 bytes of checksum, and then 1 byte compression method byte (in case of LZ4, it is -126 or 0x82).
Since 32 can be part of the checksum, we dedicate 16 bytes of 0 to be a special checksum to indicate alb keep alive response.

Note:
- related change in pbproxy: https://github.com/firebolt-analytics/pbproxy/pull/127
- this change is not backward compatible, but backward compatible is not an concern since compressed path never works...
- this change only addresses the problem that keep alive is at the beginning of the stream, and is not going to address problem that some compressed chunk is written, and then alb keep alive, and more compressed chunks, etc

## Test:
passing exiting test, and jdbc test:
./gradlew integrationTest -Ddb=local_dev_db -Dapi=localhost:9090 --tests="*shouldExecuteRequestWithoutTimeout*"