### PR TITLE
FIR-10166 updated jackson version to the latest one 2.15.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ sourceSets {
 dependencies {
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'com.google.guava:guava:31.1-jre'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
     implementation 'commons-codec:commons-codec:1.15'
     implementation 'net.jodah:expiringmap:0.5.10'
     implementation 'org.apache.commons:commons-text:1.10.0'


### PR DESCRIPTION
This is inspired by an old issue FIR-10166 that complains about the vulnerabilities in this library. The upgrade is done although this library was updated to pretty good version a year ago, but anyway it is good to keep all dependencies up-to-date.