### PR TITLE
ci: Use PAT for release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         name: ${{ needs.build.outputs.sources-jar }}
     - uses: xresloader/upload-to-github-release@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GH_PAT }}
       with:
         file: ${{ needs.build.outputs.uber-jar }}
         tags: true


### PR DESCRIPTION
I think this might be preventing us from running release as hinted  in https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow