### PR TITLE
FIR-28894: Allow looking up engine URIs and database schemas in catalog 

### DIFF
--- a/src/main/java/com/firebolt/jdbc/client/query/StatementClientImpl.java
+++ b/src/main/java/com/firebolt/jdbc/client/query/StatementClientImpl.java
@@ -232,7 +232,7 @@ public class StatementClientImpl extends FireboltClient implements StatementClie
 	}
 
 	private URI buildQueryUri(FireboltProperties fireboltProperties, Map<String, String> parameters) {
-		return buildURI(fireboltProperties, parameters, Collections.emptyList());
+		return buildURI(fireboltProperties, parameters, Collections.singletonList("query"));
 	}
 
 	private URI buildCancelUri(FireboltProperties fireboltProperties, String id) {
@@ -245,8 +245,8 @@ public class StatementClientImpl extends FireboltClient implements StatementClie
 		HttpUrl.Builder httpUrlBuilder = new HttpUrl.Builder()
 				.scheme(fireboltProperties.isSsl() ? "https" : "http")
 				.host(fireboltProperties.getHost())
-				.addPathSegment("query")
 				.port(fireboltProperties.getPort());
+
 		parameters.forEach(httpUrlBuilder::addQueryParameter);
 
 		pathSegments.forEach(httpUrlBuilder::addPathSegment);

--- a/src/main/java/com/firebolt/jdbc/connection/Engine.java
+++ b/src/main/java/com/firebolt/jdbc/connection/Engine.java
@@ -1,5 +1,9 @@
 package com.firebolt.jdbc.connection;
 
+import java.util.List;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
 import lombok.*;
 
 @AllArgsConstructor
@@ -11,4 +15,5 @@ public class Engine {
 	private final String name;
 	private final String database;
 	private final String id;
+	private final List<ImmutablePair<String, String>> queryParams;
 }

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecret.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecret.java
@@ -89,6 +89,7 @@ public class FireboltConnectionServiceSecret extends FireboltConnection {
                 .engine(engine.getName()) // engine name is updated here because this code is running either if engine has been supplied in initial parameters or when default engine for current DB was discovered
                 .systemEngine(false) // this is definitely not system engine
                 .database(engine.getDatabase()) // DB is updated because this code is running either when DB was supplied in initial parameters or not
+                .queryParams(engine.getQueryParams()) // When we look up the URL, we may get additional query params to set.
                 .build();
     }
 

--- a/src/main/java/com/firebolt/jdbc/connection/settings/FireboltProperties.java
+++ b/src/main/java/com/firebolt/jdbc/connection/settings/FireboltProperties.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 
@@ -63,6 +64,7 @@ public class FireboltProperties {
 	final String principal;
 	final String secret;
 	String engine;
+	List<ImmutablePair<String, String>> queryParams;
 	final String account;
 	final String accountId;
 	final Integer tcpKeepIdle;

--- a/src/main/java/com/firebolt/jdbc/connection/settings/FireboltProperties.java
+++ b/src/main/java/com/firebolt/jdbc/connection/settings/FireboltProperties.java
@@ -93,6 +93,7 @@ public class FireboltProperties {
 		boolean isSystemEngine = isSystemEngine(engine);
 		boolean compress = ((Boolean) getSetting(mergedProperties, FireboltSessionProperty.COMPRESS))
 				&& !isSystemEngine;
+		List<ImmutablePair<String, String>> queryParams = new ArrayList<>(); 
 		String account = getSetting(mergedProperties, FireboltSessionProperty.ACCOUNT);
 		int keepAliveMillis = getSetting(mergedProperties, FireboltSessionProperty.KEEP_ALIVE_TIMEOUT_MILLIS);
 		int maxTotal = getSetting(mergedProperties, FireboltSessionProperty.MAX_CONNECTIONS_TOTAL);
@@ -115,8 +116,8 @@ public class FireboltProperties {
 
 		Map<String, String> additionalProperties = new HashMap<>(getFireboltCustomProperties(mergedProperties)); // wrap with HashMap to make these properties updatable
 
-		return FireboltProperties.builder().ssl(ssl).sslCertificatePath(sslRootCertificate).sslMode(sslMode).path(path)
-				.port(port).database(database).compress(compress).principal(principal).secret(secret).host(host)
+		return FireboltProperties.builder().ssl(ssl).sslCertificatePath(sslRootCertificate).sslMode(sslMode).queryParams(queryParams)
+				.path(path).port(port).database(database).compress(compress).principal(principal).secret(secret).host(host)
 				.additionalProperties(additionalProperties).account(account).engine(engine)
 				.keepAliveTimeoutMillis(keepAliveMillis).maxConnectionsTotal(maxTotal).maxRetries(maxRetries)
 				.bufferSize(bufferSize).socketTimeoutMillis(socketTimeout).connectionTimeoutMillis(connectionTimeout)

--- a/src/main/java/com/firebolt/jdbc/service/FireboltEngineApiService.java
+++ b/src/main/java/com/firebolt/jdbc/service/FireboltEngineApiService.java
@@ -14,6 +14,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -78,7 +79,14 @@ public class FireboltEngineApiService implements FireboltEngineService {
 
         return ofNullable(fireboltEngineResponse).map(FireboltEngineResponse::getEngine)
                 .filter(e -> StringUtils.isNotEmpty(e.getEndpoint()))
-                .map(e -> new Engine(e.getEndpoint(), e.getCurrentStatus(), engineName, null, engineID))
+                .map(e -> 
+                    new Engine(
+                        e.getEndpoint(),
+                        e.getCurrentStatus(),
+                        engineName, 
+                        null,
+                        engineID,
+                        Collections.emptyList()))
                 .orElseThrow(() -> new FireboltException(
                         String.format(ERROR_NO_ENGINE_WITH_NAME, connectionUrl, engineName)));
     }
@@ -89,7 +97,14 @@ public class FireboltEngineApiService implements FireboltEngineService {
                 .getDefaultEngineByDatabaseName(connectionUrl, accountId, database, accessToken);
 
         return ofNullable(defaultEngine).map(FireboltDefaultDatabaseEngineResponse::getEngineUrl)
-                .map(url -> new Engine(url, "running", null, database, null)).orElseThrow(
+                .map(url -> new Engine(
+                    url,
+                    "running",
+                    null,
+                    database,
+                    null,
+                    Collections.emptyList()))
+                .orElseThrow(
                         () -> new FireboltException(String.format(ERROR_NO_ENGINE_ATTACHED, connectionUrl, database)));
     }
 

--- a/src/main/java/com/firebolt/jdbc/service/FireboltEngineInformationSchemaService.java
+++ b/src/main/java/com/firebolt/jdbc/service/FireboltEngineInformationSchemaService.java
@@ -8,31 +8,68 @@ import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import static java.lang.String.format;
 
-@RequiredArgsConstructor
+import java.net.URI;
+import java.net.URISyntaxException;
+
 @CustomLog
 public class FireboltEngineInformationSchemaService implements FireboltEngineService {
     private static final String ENGINE_URL = "url";
     private static final String STATUS_FIELD = "status";
     private static final String ENGINE_NAME_FIELD = "engine_name";
-    private static final String RUNNING_STATUS = "running";
+    private static final Set<String> RUNNING_STATUS = Set.of("ENGINE_STATE_RUNNING", "RUNNING");
+    
+    
     private static final String ENGINE_QUERY =
-            "SELECT engs.url, engs.attached_to, dbs.database_name, engs.status, engs.engine_name " +
+            "SELECT engs.url, " + 
+                   "engs.default_database as default_db_name, " +
+                   "catalogs.catalog_name, "+
+                   "engs.status, " + 
+                   "engs.engine_name, " + 
+                   "dbs.database_name as attached_to_database_name " +
             "FROM information_schema.engines as engs " +
-            "LEFT JOIN information_schema.databases as dbs ON engs.attached_to = dbs.database_name " +
+            "LEFT OUTER JOIN information_schema.catalogs as catalogs ON engs.default_database = catalogs.catalog_name " +
+            "LEFT OUTER JOIN information_schema.databases as dbs ON engs.attached_to = dbs.database_name " +
             "WHERE engs.engine_name = ?";
-    private static final String DATABASE_QUERY = "SELECT database_name FROM information_schema.databases WHERE database_name=?";
+
+    private static final String DATABASE_QUERY_DATABASE_TABLE = "SELECT database_name FROM information_schema.databases WHERE database_name=?";
+    private static final String DATABASE_QUERY_CATALOG_TABLE = "SELECT catalog_name FROM information_schema.catalogs WHERE catalog_name=?";
 
     private final FireboltConnection fireboltConnection;
 
+    public FireboltEngineInformationSchemaService(FireboltConnection fireboltConnection) {
+        this.fireboltConnection = fireboltConnection;
+    }
+
     @Override
     public boolean doesDatabaseExist(String database) throws SQLException {
-        try (PreparedStatement ps = fireboltConnection.prepareStatement(DATABASE_QUERY)) {
+        if (fireboltConnection.getProtocolVersion() != "2.0") {
+            try (PreparedStatement ps = fireboltConnection.prepareStatement(DATABASE_QUERY_DATABASE_TABLE)) {
+                ps.setString(1, database);
+                try (ResultSet rs = ps.executeQuery()) {
+                    boolean hasNext = rs.next();
+                    if (hasNext) {
+                        return hasNext;
+                    }
+                }
+            } 
+        }
+
+        try (PreparedStatement ps = fireboltConnection.prepareStatement(DATABASE_QUERY_CATALOG_TABLE)) {
             ps.setString(1, database);
             try (ResultSet rs = ps.executeQuery()) {
                 return rs.next();
@@ -49,29 +86,58 @@ public class FireboltEngineInformationSchemaService implements FireboltEngineSer
         if (engine == null) {
             throw new IllegalArgumentException("Cannot retrieve engine parameters because its name is null");
         }
+
+        String rawUrl = "";
+        String attachedDatabase = null;
+        String engineName = "";
+        String status = "";
+
         try (PreparedStatement ps = fireboltConnection.prepareStatement(ENGINE_QUERY)) {
             ps.setString(1, engine);
             try (ResultSet rs = ps.executeQuery()) {
                 if (!rs.next()) {
                     throw new FireboltException(format("The engine with the name %s could not be found", engine));
                 }
-                String status = rs.getString(STATUS_FIELD);
-                if (!isEngineRunning(status)) {
-                    throw new FireboltException(format("The engine with the name %s is not running. Status: %s", engine, status));
-                }
-                String attachedDatabase = rs.getString("attached_to");
+                status = rs.getString(STATUS_FIELD);
+                engineName = rs.getString(ENGINE_NAME_FIELD);
+                attachedDatabase = rs.getString("attached_to_database_name");
                 if (attachedDatabase == null) {
-                    throw new FireboltException(format("The engine with the name %s is not attached to any database", engine));
+                    attachedDatabase = rs.getString("default_db_name");
                 }
-                if (database != null && !database.equals(attachedDatabase)) {
-                    throw new FireboltException(format("The engine with the name %s is not attached to database %s", engine, database));
-                }
-                return new Engine(rs.getString(ENGINE_URL), status, rs.getString(ENGINE_NAME_FIELD), attachedDatabase, null);
+                rawUrl = rs.getString(ENGINE_URL);
             }
+
+            if (!isEngineRunning(status)) {
+                throw new FireboltException(format("The engine with the name %s is not running. Status: %s", engine, status));
+            }
+            if (attachedDatabase == null) {
+                throw new FireboltException(format("The engine with the name %s is not attached to any database", engine));
+            }
+
+            // If the engine url has query parameters, we want to keep them and send on requests. 
+            String hostUrl = rawUrl;
+            URI uri = new URI(rawUrl);
+
+            if (rawUrl.indexOf("?") != -1) {
+                hostUrl = rawUrl.substring(0, rawUrl.indexOf("?"));
+            }
+
+            List<ImmutablePair<String, String>> queryParams = new ArrayList<>();
+            String query = uri.getQuery();
+            if (query != null) {
+                for (String param : query.split("&")) {
+                    String[] pair = param.split("=");
+                    queryParams.add(new ImmutablePair<String, String>(pair[0], pair[1]));
+                }
+            }
+
+            return new Engine(hostUrl, status, engineName, attachedDatabase, null, queryParams);
+        } catch (URISyntaxException e) {
+            throw new FireboltException(format("The engine with the name %s has an invalid url", engine), e);
         }
     }
 
     private boolean isEngineRunning(String status) {
-        return RUNNING_STATUS.equalsIgnoreCase(status);
+        return RUNNING_STATUS.contains(status.toUpperCase());
     }
 }

--- a/src/main/java/com/firebolt/jdbc/service/FireboltEngineInformationSchemaService.java
+++ b/src/main/java/com/firebolt/jdbc/service/FireboltEngineInformationSchemaService.java
@@ -57,17 +57,15 @@ public class FireboltEngineInformationSchemaService implements FireboltEngineSer
 
     @Override
     public boolean doesDatabaseExist(String database) throws SQLException {
-        if (fireboltConnection.getProtocolVersion() != "2.0") {
-            try (PreparedStatement ps = fireboltConnection.prepareStatement(DATABASE_QUERY_DATABASE_TABLE)) {
-                ps.setString(1, database);
-                try (ResultSet rs = ps.executeQuery()) {
-                    boolean hasNext = rs.next();
-                    if (hasNext) {
-                        return hasNext;
-                    }
+        try (PreparedStatement ps = fireboltConnection.prepareStatement(DATABASE_QUERY_DATABASE_TABLE)) {
+            ps.setString(1, database);
+            try (ResultSet rs = ps.executeQuery()) {
+                boolean hasNext = rs.next();
+                if (hasNext) {
+                    return hasNext;
                 }
-            } 
-        }
+            }
+        } 
 
         try (PreparedStatement ps = fireboltConnection.prepareStatement(DATABASE_QUERY_CATALOG_TABLE)) {
             ps.setString(1, database);
@@ -110,9 +108,6 @@ public class FireboltEngineInformationSchemaService implements FireboltEngineSer
             if (!isEngineRunning(status)) {
                 throw new FireboltException(format("The engine with the name %s is not running. Status: %s", engine, status));
             }
-            if (attachedDatabase == null) {
-                throw new FireboltException(format("The engine with the name %s is not attached to any database", engine));
-            }
 
             // If the engine url has query parameters, we want to keep them and send on requests. 
             String hostUrl = rawUrl;
@@ -129,6 +124,10 @@ public class FireboltEngineInformationSchemaService implements FireboltEngineSer
                     String[] pair = param.split("=");
                     queryParams.add(new ImmutablePair<String, String>(pair[0], pair[1]));
                 }
+            }
+
+            if (attachedDatabase == null) {
+                throw new FireboltException(format("The engine with the name %s is not attached to any database", engine));
             }
 
             return new Engine(hostUrl, status, engineName, attachedDatabase, null, queryParams);

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionTest.java
@@ -37,6 +37,7 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Savepoint;
 import java.sql.Statement;
 import java.sql.Types;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -64,6 +65,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyBoolean;
@@ -150,7 +153,7 @@ abstract class FireboltConnectionTest {
 		lenient().when(fireboltAuthenticationService.getConnectionTokens(eq("https://api.dev.firebolt.io:443"), any()))
 				.thenReturn(fireboltConnectionTokens);
 		lenient().when(fireboltGatewayUrlService.getUrl(any(), any())).thenReturn("http://foo:8080/bar");
-		engine = new Engine("endpoint", "id123", "OK", "noname", null);
+		engine = new Engine("endpoint", "id123", "OK", "noname", null, Collections.emptyList());
 		lenient().when(fireboltEngineService.getEngine(any())).thenReturn(engine);
 		lenient().when(fireboltEngineService.doesDatabaseExist(any())).thenReturn(true);
 	}
@@ -427,7 +430,7 @@ abstract class FireboltConnectionTest {
 			when(FireboltProperties.of(any())).thenReturn(fireboltProperties);
 			when(fireboltAuthenticationService.getConnectionTokens("http://host:8080", fireboltProperties))
 					.thenReturn(FireboltConnectionTokens.builder().build());
-			lenient().when(fireboltEngineService.getEngine(any())).thenReturn(new Engine("http://hello", null, null, null, null));
+			lenient().when(fireboltEngineService.getEngine(any())).thenReturn(new Engine("http://hello", null, null, null, null, Collections.emptyList()));
 
 			try (FireboltConnection fireboltConnection = createConnection(URL, connectionProperties)) {
 				fireboltConnection.removeExpiredTokens();
@@ -444,7 +447,7 @@ abstract class FireboltConnectionTest {
 			when(FireboltProperties.of(any())).thenReturn(fireboltProperties);
 			FireboltConnectionTokens connectionTokens = FireboltConnectionTokens.builder().accessToken(accessToken).build();
 			when(fireboltAuthenticationService.getConnectionTokens(eq("http://host:8080"), any())).thenReturn(connectionTokens);
-			lenient().when(fireboltEngineService.getEngine(any())).thenReturn(new Engine("http://engineHost", null, null, null, null));
+			lenient().when(fireboltEngineService.getEngine(any())).thenReturn(new Engine("http://engineHost", null, null, null, null, Collections.emptyList()));
 			try (FireboltConnection fireboltConnection = createConnection(URL, connectionProperties)) {
 				verify(fireboltAuthenticationService).getConnectionTokens("http://host:8080", fireboltProperties);
 				assertEquals(accessToken, fireboltConnection.getAccessToken().get());
@@ -593,7 +596,7 @@ abstract class FireboltConnectionTest {
 	@Test
 	void shouldGetEngineUrlWhenEngineIsProvided() throws SQLException {
 		connectionProperties.put("engine", "engine");
-		when(fireboltEngineService.getEngine(any())).thenReturn(new Engine("http://my_endpoint", null, null, null, null));
+		when(fireboltEngineService.getEngine(any())).thenReturn(new Engine("http://my_endpoint", null, null, null, null, Collections.emptyList()));
 		try (FireboltConnection connection = createConnection(URL, connectionProperties)) {
 			verify(fireboltEngineService).getEngine(argThat(props -> "engine".equals(props.getEngine()) && "db".equals(props.getDatabase())));
 			assertEquals("http://my_endpoint", connection.getSessionProperties().getHost());

--- a/src/test/java/com/firebolt/jdbc/connection/settings/FireboltPropertiesTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/settings/FireboltPropertiesTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -22,7 +24,7 @@ class FireboltPropertiesTest {
 	void shouldHaveDefaultPropertiesWhenOnlyTheRequiredFieldsAreSpecified() {
 		FireboltProperties expectedDefaultProperties = FireboltProperties.builder().engine("engine").database("db").bufferSize(65536)
 				.sslCertificatePath("").sslMode("strict").path("").port(443) // 443 by default as SSL is enabled by
-				.systemEngine(false).compress(true)													// default
+				.systemEngine(false).compress(true).queryParams(Collections.emptyList())    // default
 				.principal(null).secret(null).host("host").ssl(true).additionalProperties(new HashMap<>())
 				.keepAliveTimeoutMillis(300000).maxConnectionsTotal(300).maxRetries(3)
 				.socketTimeoutMillis(0).connectionTimeoutMillis(60000).tcpKeepInterval(30).environment("app").tcpKeepIdle(60)
@@ -56,7 +58,7 @@ class FireboltPropertiesTest {
 		FireboltProperties expectedDefaultProperties = FireboltProperties.builder().engine("my_test").bufferSize(51)
 				.sslCertificatePath("root_cert").sslMode("none").path("example").database("myDb").compress(true)
 				.port(443).principal(null).secret(null).host("myDummyHost").ssl(true).systemEngine(false)
-				.additionalProperties(customProperties).keepAliveTimeoutMillis(300000)
+				.additionalProperties(customProperties).keepAliveTimeoutMillis(300000).queryParams(Collections.emptyList())
 				.maxConnectionsTotal(300).maxRetries(3).socketTimeoutMillis(20).connectionTimeoutMillis(60000)
 				.tcpKeepInterval(30).tcpKeepIdle(60).tcpKeepCount(10).environment("app").build();
 		assertEquals(expectedDefaultProperties, FireboltProperties.of(properties));

--- a/src/test/java/com/firebolt/jdbc/metadata/FireboltDatabaseMetadataTest.java
+++ b/src/test/java/com/firebolt/jdbc/metadata/FireboltDatabaseMetadataTest.java
@@ -101,7 +101,12 @@ class FireboltDatabaseMetadataTest {
 		lenient().when(fireboltConnection.createStatement(any())).thenReturn(statement);
 		lenient().when(fireboltConnection.createStatement()).thenReturn(statement);
 		lenient().when(fireboltConnection.getCatalog()).thenReturn("db_name");
-		lenient().when(fireboltConnection.getSessionProperties()).thenReturn(FireboltProperties.builder().database("my-db").build());
+		lenient().when(fireboltConnection.getSessionProperties()).thenReturn(
+			FireboltProperties
+				.builder()
+				.database("my-db")
+				.queryParams(Collections.emptyList())
+				.build());
 		lenient().when(statement.executeQuery(anyString())).thenReturn(FireboltResultSet.empty());
 	}
 

--- a/src/test/java/com/firebolt/jdbc/service/FireboltEngineInformationSchemaServiceTest.java
+++ b/src/test/java/com/firebolt/jdbc/service/FireboltEngineInformationSchemaServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -53,7 +54,7 @@ class FireboltEngineInformationSchemaServiceTest {
 		ResultSet resultSet = mockedResultSet(Map.of("status", "running", "url", "https://url", "attached_to", "db", "engine_name", "some-engine"));
 		when(fireboltConnection.prepareStatement(anyString())).thenReturn(statement);
 		when(statement.executeQuery()).thenReturn(resultSet);
-		assertEquals(new Engine("https://url", "running", "some-engine", "db", null), fireboltEngineService.getEngine(createFireboltProperties("some-engine", "db")));
+		assertEquals(new Engine("https://url", "running", "some-engine", "db", null, Collections.emptyList()), fireboltEngineService.getEngine(createFireboltProperties("some-engine", "db")));
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
What:
- Change queries we use to look up the engine URI and default database from an engine to account for catalog information_schema table.
- Pass along any query params that come with the uri that we look up
