### PR TITLE
improved FireboltProperties: removed of() factory method, added constructors

### DIFF
--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnection.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnection.java
@@ -132,7 +132,7 @@ public abstract class FireboltConnection implements Connection {
 		if (allSettings.containsKey("client_id") && allSettings.containsKey("client_secret") && !allSettings.containsKey("user") && !allSettings.containsKey("password")) {
 			return 2;
 		}
-		FireboltProperties props = FireboltProperties.of(propertiesFromUrl, connectionSettings);
+		FireboltProperties props = new FireboltProperties(new Properties[] {propertiesFromUrl, connectionSettings});
 		String principal = props.getPrincipal();
 		if (principal != null && principal.contains("@")) {
 			return 1;
@@ -330,8 +330,7 @@ public abstract class FireboltConnection implements Connection {
 	}
 
 	private static FireboltProperties createFireboltProperties(String jdbcUri, Properties connectionProperties) {
-		Properties propertiesFromUrl = UrlUtil.extractProperties(jdbcUri);
-		return FireboltProperties.of(propertiesFromUrl, connectionProperties);
+		return new FireboltProperties(new Properties[] {UrlUtil.extractProperties(jdbcUri), connectionProperties});
 	}
 
 	@Override

--- a/src/main/java/com/firebolt/jdbc/connection/settings/FireboltProperties.java
+++ b/src/main/java/com/firebolt/jdbc/connection/settings/FireboltProperties.java
@@ -1,5 +1,6 @@
 package com.firebolt.jdbc.connection.settings;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.CustomLog;
 import lombok.EqualsAndHashCode;
@@ -28,6 +29,7 @@ import static java.lang.String.format;
 
 @Getter
 @ToString
+@AllArgsConstructor
 @EqualsAndHashCode
 @Builder(toBuilder = true)
 @CustomLog
@@ -45,86 +47,74 @@ public class FireboltProperties {
 				return keys;
 			}).flatMap(List::stream).collect(Collectors.toSet());
 
-	final int keepAliveTimeoutMillis;
-	final int maxConnectionsTotal;
-	final int maxRetries;
-	final int bufferSize;
-	final int clientBufferSize;
-	final int socketTimeoutMillis;
-	final int connectionTimeoutMillis;
-	final Integer port;
-	final String host;
-	String database;
-	final String path;
-	final boolean ssl;
-	final String sslCertificatePath;
-	final String sslMode;
-	final boolean compress;
-	final String principal;
-	final String secret;
-	String engine;
-	final String account;
-	final String accountId;
-	final Integer tcpKeepIdle;
-	final Integer tcpKeepCount;
-	final Integer tcpKeepInterval;
-	final boolean logResultSet;
-	boolean systemEngine;
-	final String environment;
-	final String userDrivers;
-	final String userClients;
-	final String accessToken;
-
+	private final int keepAliveTimeoutMillis;
+	private final int maxConnectionsTotal;
+	private final int maxRetries;
+	private final int bufferSize;
+	private final int socketTimeoutMillis;
+	private final int connectionTimeoutMillis;
+	private final Integer port;
+	private final String host;
+	private String database; // updatable using use statement
+	private final String path;
+	private final boolean ssl;
+	private final String sslCertificatePath;
+	private final String sslMode;
+	private final boolean compress;
+	private final String principal;
+	private final String secret;
+	private String engine; // updatable using use statement
+	private final String account;
+	private final String accountId;
+	private final int tcpKeepIdle;
+	private final int tcpKeepCount;
+	private final int tcpKeepInterval;
+	private final boolean logResultSet;
+	private boolean systemEngine;
+	private final String environment;
+	private final String userDrivers;
+	private final String userClients;
+	private final String accessToken;
 	@Builder.Default
-	final Map<String, String> additionalProperties = new HashMap<>();
+	Map<String, String> additionalProperties = new HashMap<>();
 
-	public static FireboltProperties of(Properties... properties) {
-		Properties mergedProperties = mergeProperties(properties);
-		boolean ssl = getSetting(mergedProperties, FireboltSessionProperty.SSL);
-		String sslRootCertificate = getSetting(mergedProperties, FireboltSessionProperty.SSL_CERTIFICATE_PATH);
-		String sslMode = getSetting(mergedProperties, FireboltSessionProperty.SSL_MODE);
-		String principal = getSetting(mergedProperties, FireboltSessionProperty.CLIENT_ID);
-		String secret = getSetting(mergedProperties, FireboltSessionProperty.CLIENT_SECRET);
-		String path = getSetting(mergedProperties, FireboltSessionProperty.PATH);
-		String database = getDatabase(mergedProperties, path);
-		String engine = getEngine(mergedProperties);
-		boolean isSystemEngine = isSystemEngine(engine);
-		boolean compress = ((Boolean) getSetting(mergedProperties, FireboltSessionProperty.COMPRESS))
-				&& !isSystemEngine;
-		String account = getSetting(mergedProperties, FireboltSessionProperty.ACCOUNT);
-		int keepAliveMillis = getSetting(mergedProperties, FireboltSessionProperty.KEEP_ALIVE_TIMEOUT_MILLIS);
-		int maxTotal = getSetting(mergedProperties, FireboltSessionProperty.MAX_CONNECTIONS_TOTAL);
-		int maxRetries = getSetting(mergedProperties, FireboltSessionProperty.MAX_RETRIES);
-		int bufferSize = getSetting(mergedProperties, FireboltSessionProperty.BUFFER_SIZE);
-		int socketTimeout = getSetting(mergedProperties, FireboltSessionProperty.SOCKET_TIMEOUT_MILLIS);
-		int connectionTimeout = getSetting(mergedProperties, FireboltSessionProperty.CONNECTION_TIMEOUT_MILLIS);
-		int tcpKeepInterval = getSetting(mergedProperties, FireboltSessionProperty.TCP_KEEP_INTERVAL);
-		int tcpKeepIdle = getSetting(mergedProperties, FireboltSessionProperty.TCP_KEEP_IDLE);
-		int tcpKeepCount = getSetting(mergedProperties, FireboltSessionProperty.TCP_KEEP_COUNT);
-		boolean logResultSet = getSetting(mergedProperties, FireboltSessionProperty.LOG_RESULT_SET);
-		String configuredEnvironment = getSetting(mergedProperties, FireboltSessionProperty.ENVIRONMENT);
-		String driverVersions = getSetting(mergedProperties, FireboltSessionProperty.USER_DRIVERS);
-		String clientVersions = getSetting(mergedProperties, FireboltSessionProperty.USER_CLIENTS);
+	public FireboltProperties(Properties[] allProperties) {
+		this(mergeProperties(allProperties));
+	}
 
-		String environment = getEnvironment(configuredEnvironment, mergedProperties);
-		String host = getHost(configuredEnvironment, mergedProperties);
-		Integer port = getPort(mergedProperties, ssl);
-		String accessToken =  getSetting(mergedProperties, FireboltSessionProperty.ACCESS_TOKEN);
+	public FireboltProperties(Properties properties) {
+		ssl = getSetting(properties, FireboltSessionProperty.SSL);
+		sslCertificatePath = getSetting(properties, FireboltSessionProperty.SSL_CERTIFICATE_PATH);
+		sslMode = getSetting(properties, FireboltSessionProperty.SSL_MODE);
+		principal = getSetting(properties, FireboltSessionProperty.CLIENT_ID);
+		secret = getSetting(properties, FireboltSessionProperty.CLIENT_SECRET);
+		path = getSetting(properties, FireboltSessionProperty.PATH);
+		database = getDatabase(properties, path);
+		engine = getEngine(properties);
+		systemEngine = isSystemEngine(engine);
+		compress = ((Boolean) getSetting(properties, FireboltSessionProperty.COMPRESS)) && !systemEngine;
+		account = getSetting(properties, FireboltSessionProperty.ACCOUNT);
+		accountId = getSetting(properties, FireboltSessionProperty.ACCOUNT_ID);
+		keepAliveTimeoutMillis = getSetting(properties, FireboltSessionProperty.KEEP_ALIVE_TIMEOUT_MILLIS);
+		maxConnectionsTotal = getSetting(properties, FireboltSessionProperty.MAX_CONNECTIONS_TOTAL);
+		maxRetries = getSetting(properties, FireboltSessionProperty.MAX_RETRIES);
+		bufferSize = getSetting(properties, FireboltSessionProperty.BUFFER_SIZE);
+		socketTimeoutMillis = getSetting(properties, FireboltSessionProperty.SOCKET_TIMEOUT_MILLIS);
+		connectionTimeoutMillis = getSetting(properties, FireboltSessionProperty.CONNECTION_TIMEOUT_MILLIS);
+		tcpKeepInterval = getSetting(properties, FireboltSessionProperty.TCP_KEEP_INTERVAL);
+		tcpKeepIdle = getSetting(properties, FireboltSessionProperty.TCP_KEEP_IDLE);
+		tcpKeepCount = getSetting(properties, FireboltSessionProperty.TCP_KEEP_COUNT);
+		logResultSet = getSetting(properties, FireboltSessionProperty.LOG_RESULT_SET);
+		String configuredEnvironment = getSetting(properties, FireboltSessionProperty.ENVIRONMENT);
+		userDrivers = getSetting(properties, FireboltSessionProperty.USER_DRIVERS);
+		userClients = getSetting(properties, FireboltSessionProperty.USER_CLIENTS);
 
-		Map<String, String> additionalProperties = new HashMap<>(getFireboltCustomProperties(mergedProperties)); // wrap with HashMap to make these properties updatable
+		environment = getEnvironment(configuredEnvironment, properties);
+		host = getHost(configuredEnvironment, properties);
+		port = getPort(properties, ssl);
+		accessToken =  getSetting(properties, FireboltSessionProperty.ACCESS_TOKEN);
 
-		return FireboltProperties.builder().ssl(ssl).sslCertificatePath(sslRootCertificate).sslMode(sslMode).path(path)
-				.port(port).database(database).compress(compress).principal(principal).secret(secret).host(host)
-				.additionalProperties(additionalProperties).account(account).engine(engine)
-				.keepAliveTimeoutMillis(keepAliveMillis).maxConnectionsTotal(maxTotal).maxRetries(maxRetries)
-				.bufferSize(bufferSize).socketTimeoutMillis(socketTimeout).connectionTimeoutMillis(connectionTimeout)
-				.tcpKeepInterval(tcpKeepInterval).tcpKeepCount(tcpKeepCount).tcpKeepIdle(tcpKeepIdle)
-				.logResultSet(logResultSet).systemEngine(isSystemEngine)
-				.environment(environment)
-				.userDrivers(driverVersions)
-				.userClients(clientVersions)
-				.accessToken(accessToken)
-				.build();
+		additionalProperties = new HashMap<>(getFireboltCustomProperties(properties)); // wrap with HashMap to make these properties updatable
 	}
 
 	private static String getEngine(Properties mergedProperties) {
@@ -133,11 +123,7 @@ public class FireboltProperties {
 
 	private static String getHost(String environment, Properties properties ) {
 		String host = getSetting(properties, FireboltSessionProperty.HOST);
-		if (StringUtils.isEmpty(host)) {
-			return format("api.%s.firebolt.io", environment);
-		} else {
-			return host;
-		}
+		return host == null || host.isEmpty() ? format("api.%s.firebolt.io", environment) : host;
 	}
 
 	/**
@@ -263,5 +249,4 @@ public class FireboltProperties {
 		String protocol = isSsl() ? "https://" : "http://";
 		return protocol + hostAndPort;
 	}
-
 }

--- a/src/test/java/com/firebolt/jdbc/client/HttpClientConfigTest.java
+++ b/src/test/java/com/firebolt/jdbc/client/HttpClientConfigTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.lang.reflect.Field;
+import java.util.Properties;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,7 @@ class HttpClientConfigTest {
 	@Test
 	void shouldInitHttpClient() throws Exception {
 		assertNull(HttpClientConfig.getInstance());
-		OkHttpClient client = HttpClientConfig.init(FireboltProperties.of());
+		OkHttpClient client = HttpClientConfig.init(new FireboltProperties(new Properties()));
 		assertNotNull(client);
 		assertSame(client, HttpClientConfig.getInstance());
 	}

--- a/src/test/java/com/firebolt/jdbc/client/query/StatementClientImplTest.java
+++ b/src/test/java/com/firebolt/jdbc/client/query/StatementClientImplTest.java
@@ -231,7 +231,7 @@ class StatementClientImplTest {
 		props.setProperty("host", "firebolt1");
 		props.setProperty("port", "555");
 		props.setProperty(FireboltSessionProperty.CONNECTION_TIMEOUT_MILLIS.getKey(), "0"); // simplifies mocking
-		FireboltProperties fireboltProperties = FireboltProperties.of(props);
+		FireboltProperties fireboltProperties = new FireboltProperties(props);
 		Call okCall = getMockedCallWithResponse(200, "", responseHeaders);
 		when(okHttpClient.newCall(any())).thenReturn(okCall);
 		FireboltAuthenticationService fireboltAuthenticationService = mock(FireboltAuthenticationService.class);

--- a/src/test/java/com/firebolt/jdbc/connection/settings/FireboltPropertiesTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/settings/FireboltPropertiesTest.java
@@ -32,7 +32,7 @@ class FireboltPropertiesTest {
 		properties.put("engine", "engine");
 		properties.put("host", "host");
 		properties.put("database", "db");
-		assertEquals(expectedDefaultProperties, FireboltProperties.of(properties));
+		assertEquals(expectedDefaultProperties, new FireboltProperties(properties));
 	}
 
 	@Test
@@ -59,12 +59,12 @@ class FireboltPropertiesTest {
 				.additionalProperties(customProperties).keepAliveTimeoutMillis(300000)
 				.maxConnectionsTotal(300).maxRetries(3).socketTimeoutMillis(20).connectionTimeoutMillis(60000)
 				.tcpKeepInterval(30).tcpKeepIdle(60).tcpKeepCount(10).environment("app").build();
-		assertEquals(expectedDefaultProperties, FireboltProperties.of(properties));
+		assertEquals(expectedDefaultProperties, new FireboltProperties(properties));
 	}
 
 	@Test
 	void shouldAddAdditionalProperties() {
-		FireboltProperties props = FireboltProperties.of();
+		FireboltProperties props = new FireboltProperties(new Properties());
 		assertTrue(props.getAdditionalProperties().isEmpty());
 		props.addProperty(new ImmutablePair<>("a", "1"));
 		props.addProperty("b", "2");
@@ -77,7 +77,7 @@ class FireboltPropertiesTest {
 		properties.put("path", "example");
 		properties.put("host", "host");
 
-		assertEquals("example", FireboltProperties.of(properties).getDatabase());
+		assertEquals("example", new FireboltProperties(properties).getDatabase());
 	}
 
 	@ParameterizedTest
@@ -85,7 +85,7 @@ class FireboltPropertiesTest {
 	void invalidDatabase(String db) {
 		Properties properties = new Properties();
 		properties.put("path", db);
-		assertThrows(IllegalArgumentException.class, () -> FireboltProperties.of(properties));
+		assertThrows(IllegalArgumentException.class, () -> new FireboltProperties(properties));
 	}
 
 	@Test
@@ -93,12 +93,12 @@ class FireboltPropertiesTest {
 		Properties properties = new Properties();
 		properties.put("path", "example");
 		properties.put("host", "host");
-		assertEquals(FireboltProperties.of(properties), FireboltProperties.copy(FireboltProperties.of(properties)));
+		assertEquals(new FireboltProperties(properties), FireboltProperties.copy(new FireboltProperties(properties)));
 	}
 
 	@Test
 	void notEmptyCopy() {
-		assertEquals(FireboltProperties.of(), FireboltProperties.copy(FireboltProperties.of()));
+		assertEquals(new FireboltProperties(new Properties()), FireboltProperties.copy(new FireboltProperties(new Properties())));
 	}
 
 	@Test
@@ -109,8 +109,8 @@ class FireboltPropertiesTest {
 		properties.put("ssl", "true");
 		properties.put("compress", "false");
 
-		assertTrue(FireboltProperties.of(properties).isSsl());
-		assertFalse(FireboltProperties.of(properties).isCompress());
+		assertTrue(new FireboltProperties(properties).isSsl());
+		assertFalse(new FireboltProperties(properties).isCompress());
 	}
 
 	@Test
@@ -121,8 +121,8 @@ class FireboltPropertiesTest {
 		properties.put("ssl", "2");
 		properties.put("compress", "0");
 
-		assertTrue(FireboltProperties.of(properties).isSsl());
-		assertFalse(FireboltProperties.of(properties).isCompress());
+		assertTrue(new FireboltProperties(properties).isSsl());
+		assertFalse(new FireboltProperties(properties).isCompress());
 	}
 
 	@Test
@@ -132,13 +132,13 @@ class FireboltPropertiesTest {
 		properties.put("host", "host");
 		properties.put("port", "999");
 
-		assertEquals(999, FireboltProperties.of(properties).getPort());
+		assertEquals(999, new FireboltProperties(properties).getPort());
 	}
 
 	@Test
 	void shouldUseSystemEngineWhenNoDbOrEngineProvided() {
 		Properties properties = new Properties();
-		FireboltProperties fireboltProperties = FireboltProperties.of(properties);
+		FireboltProperties fireboltProperties = new FireboltProperties(properties);
 		assertTrue(fireboltProperties.isSystemEngine());
 		assertNull(fireboltProperties.getEngine());
 		assertNull(fireboltProperties.getDatabase());
@@ -155,13 +155,13 @@ class FireboltPropertiesTest {
 		properties.put("host", "host");
 		properties.put("database", "db");
 
-		assertEquals(clients, FireboltProperties.of(properties).getUserClients());
-		assertEquals(drivers, FireboltProperties.of(properties).getUserDrivers());
+		assertEquals(clients, new FireboltProperties(properties).getUserClients());
+		assertEquals(drivers, new FireboltProperties(properties).getUserDrivers());
 	}
 
 	@Test
 	void noEngineNoDbSystemEngine() {
-		assertNull(FireboltProperties.of(new Properties()).getEngine());
+		assertNull(new FireboltProperties(new Properties()).getEngine());
 	}
 
 	@ParameterizedTest
@@ -178,8 +178,8 @@ class FireboltPropertiesTest {
 	}, delimiter = ',')
 	void hostAndEnvironment(String envKey, String envValue, String host, String expectedHost, String expectedEnvironment) {
 		Properties properties = properties(envKey, envValue, host);
-		assertEquals(expectedHost, FireboltProperties.of(properties).getHost());
-		assertEquals(expectedEnvironment, FireboltProperties.of(properties).getEnvironment());
+		assertEquals(expectedHost, new FireboltProperties(properties).getHost());
+		assertEquals(expectedEnvironment, new FireboltProperties(properties).getEnvironment());
 	}
 
 	@ParameterizedTest
@@ -189,7 +189,7 @@ class FireboltPropertiesTest {
 	}, delimiter = ',')
 	void environmentDoesNotMatch(String envKey, String envValue, String host) {
 		Properties properties = properties(envKey, envValue, host);
-		assertThrows(IllegalStateException.class, () -> FireboltProperties.of(properties));
+		assertThrows(IllegalStateException.class, () -> new FireboltProperties(properties));
 	}
 
 	private Properties properties(String envKey, String envValue, String host) {


### PR DESCRIPTION
The annoying factory method `of()` is removed. Now we have constructor that accepts `Properties` instead. Constructor can guarantee that all `final` members are initialised. 