### PR TITLE
fix: Add protocol to system engine

### DIFF
--- a/src/main/java/com/firebolt/jdbc/service/FireboltGatewayUrlService.java
+++ b/src/main/java/com/firebolt/jdbc/service/FireboltGatewayUrlService.java
@@ -10,7 +10,15 @@ public class FireboltGatewayUrlService {
 
     private final FireboltAccountRetriever<GatewayUrlResponse> fireboltGatewayUrlClient;
 
+    private String addProtocolToUrl(String url) {
+        if (!url.startsWith("http")) {
+            // assume secure connection
+            url = "https://" + url;
+        }
+        return url;
+    }
+
     public String getUrl(String accessToken, String account) throws FireboltException {
-        return fireboltGatewayUrlClient.retrieve(accessToken, account).getEngineUrl();
+        return addProtocolToUrl(fireboltGatewayUrlClient.retrieve(accessToken, account).getEngineUrl());
     }
 }

--- a/src/test/java/com/firebolt/jdbc/service/FireboltGatewayUrlServiceTest.java
+++ b/src/test/java/com/firebolt/jdbc/service/FireboltGatewayUrlServiceTest.java
@@ -1,0 +1,31 @@
+package com.firebolt.jdbc.service;
+
+import com.firebolt.jdbc.client.account.FireboltAccountRetriever;
+import com.firebolt.jdbc.client.gateway.GatewayUrlResponse;
+import com.firebolt.jdbc.exception.FireboltException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FireboltGatewayUrlServiceTest {
+    @ParameterizedTest
+    @CsvSource({
+            "http://host,http://host",
+            "https://host,https://host",
+            "host,https://host", // force https
+            "http://host?name=value,http://host?name=value",
+            "https://host?name=value,https://host?name=value",
+            "host?name=value,https://host?name=value",
+    })
+    void test(String rawUrl, String expectedUrl) throws FireboltException {
+        @SuppressWarnings("unchecked")
+        FireboltAccountRetriever<GatewayUrlResponse> fireboltGatewayUrlClient = mock(FireboltAccountRetriever.class);
+        when(fireboltGatewayUrlClient.retrieve("token", "account")).thenReturn(new GatewayUrlResponse(rawUrl));
+        String actualUrl = new FireboltGatewayUrlService(fireboltGatewayUrlClient).getUrl("token", "account");
+        assertEquals(expectedUrl, actualUrl);
+    }
+
+}


### PR DESCRIPTION
System engine now comes without protocol in URL. We need to account for this in code.