### PR TITLE
FIR-32353: refactored FireboltStatementService.execute()

### DIFF
--- a/src/main/java/com/firebolt/jdbc/resultset/FireboltResultSet.java
+++ b/src/main/java/com/firebolt/jdbc/resultset/FireboltResultSet.java
@@ -4,6 +4,7 @@ import com.firebolt.jdbc.JdbcBase;
 import com.firebolt.jdbc.QueryResult;
 import com.firebolt.jdbc.annotation.ExcludeFromJacocoGeneratedReport;
 import com.firebolt.jdbc.annotation.NotImplemented;
+import com.firebolt.jdbc.connection.settings.FireboltProperties;
 import com.firebolt.jdbc.exception.ExceptionType;
 import com.firebolt.jdbc.exception.FireboltException;
 import com.firebolt.jdbc.exception.FireboltSQLFeatureNotSupportedException;
@@ -94,11 +95,11 @@ public class FireboltResultSet extends JdbcBase implements ResultSet {
 		this(is, null, null, null, false, null, false);
 	}
 
-	public FireboltResultSet(InputStream is, String tableName, String dbName, Integer bufferSize) throws SQLException {
+	FireboltResultSet(InputStream is, String tableName, String dbName, Integer bufferSize) throws SQLException {
 		this(is, tableName, dbName, bufferSize, false, null, false);
 	}
 
-	public FireboltResultSet(InputStream is, String tableName, String dbName, Integer bufferSize,
+	FireboltResultSet(InputStream is, String tableName, String dbName, Integer bufferSize,
 			FireboltStatement fireboltStatement) throws SQLException {
 		this(is, tableName, dbName, bufferSize, false, fireboltStatement, false);
 	}
@@ -114,13 +115,17 @@ public class FireboltResultSet extends JdbcBase implements ResultSet {
 		maxFieldSize = 0; // 0 value means unlimited
 	}
 
-	public FireboltResultSet(InputStream is, String tableName, String dbName, Integer bufferSize, boolean isCompressed,
+	FireboltResultSet(InputStream is, String tableName, String dbName, Integer bufferSize, boolean isCompressed,
 							 FireboltStatement statement, boolean logResultSet) throws SQLException {
-		this(is, tableName, dbName, bufferSize, 0, 0, isCompressed, statement, logResultSet);
+		this(is, tableName, dbName, bufferSize, statement == null ? 0 : statement.getMaxRows(), statement == null ? 0 : statement.getMaxFieldSize(), isCompressed, statement, logResultSet);
+	}
+
+	public FireboltResultSet(InputStream is, String tableName, String dbName, FireboltProperties properties, FireboltStatement statement) throws SQLException {
+		this(is, tableName, dbName, properties.getBufferSize(), statement == null ? 0 : statement.getMaxRows(), statement == null ? 0 : statement.getMaxFieldSize(), properties.isCompress(), statement, properties.isLogResultSet());
 	}
 
 	@SuppressWarnings("java:S107") //Number of parameters (8) > max (7). This is the price of the immutability
-	public FireboltResultSet(InputStream is, String tableName, String dbName, Integer bufferSize, int maxRows, int maxFieldSize, boolean isCompressed,
+	private FireboltResultSet(InputStream is, String tableName, String dbName, Integer bufferSize, int maxRows, int maxFieldSize, boolean isCompressed,
 			FireboltStatement statement, boolean logResultSet) throws SQLException {
 		log.debug("Creating resultSet...");
 		this.statement = statement;

--- a/src/main/java/com/firebolt/jdbc/service/FireboltStatementService.java
+++ b/src/main/java/com/firebolt/jdbc/service/FireboltStatementService.java
@@ -31,21 +31,18 @@ public class FireboltStatementService {
 	 *
 	 * @param statementInfoWrapper the statement info
 	 * @param properties the connection properties
-	 * @param queryTimeout         query timeout
-	 * @param maxRows              max rows
-	 * @param maxFieldSize         max field size
 	 * @param standardSql          indicates if standard sql should be used
-	 * @param systemEngine         indicates if system engine is used
 	 * @param statement           the statement
 	 * @return an InputStream with the result
 	 */
-	@SuppressWarnings("java:S107") //Number of parameters (8) > max (7). Not nice but probably not so bad for internal class
 	public Optional<ResultSet> execute(StatementInfoWrapper statementInfoWrapper,
-									   FireboltProperties properties, int queryTimeout, int maxRows, int maxFieldSize, boolean standardSql, boolean systemEngine, FireboltStatement statement)
+									   FireboltProperties properties, boolean standardSql, FireboltStatement statement)
 			throws SQLException {
+		int queryTimeout = statement.getQueryTimeout();
+		boolean systemEngine = properties.isSystemEngine();
 		InputStream is = statementClient.executeSqlStatement(statementInfoWrapper, properties, systemEngine, queryTimeout, standardSql);
 		if (statementInfoWrapper.getType() == StatementType.QUERY) {
-			return Optional.of(createResultSet(is, (QueryRawStatement) statementInfoWrapper.getInitialStatement(), properties, statement, maxRows, maxFieldSize));
+			return Optional.of(createResultSet(is, (QueryRawStatement) statementInfoWrapper.getInitialStatement(), properties, statement));
 		} else {
 			// If the statement is not a query, read all bytes from the input stream and close it.
 			// This is needed otherwise the stream with the server will be closed after having received the first chunk of data (resulting in incomplete inserts).
@@ -63,11 +60,12 @@ public class FireboltStatementService {
 		return statementClient.isStatementRunning(statementLabel);
 	}
 
-	private FireboltResultSet createResultSet(InputStream inputStream, QueryRawStatement initialQuery, FireboltProperties properties, FireboltStatement statement, int maxRows, int maxFieldSize)
+	private FireboltResultSet createResultSet(InputStream inputStream, QueryRawStatement initialQuery, FireboltProperties properties, FireboltStatement statement)
 			throws SQLException {
-		return new FireboltResultSet(inputStream, Optional.ofNullable(initialQuery.getTable()).orElse(UNKNOWN_TABLE_NAME),
+		return new FireboltResultSet(inputStream,
+				Optional.ofNullable(initialQuery.getTable()).orElse(UNKNOWN_TABLE_NAME),
 				Optional.ofNullable(initialQuery.getDatabase()).orElse(properties.getDatabase()),
-				properties.getBufferSize(), maxRows, maxFieldSize, properties.isCompress(), statement,
-				properties.isLogResultSet());
+				properties,
+				statement);
 	}
 }

--- a/src/main/java/com/firebolt/jdbc/statement/FireboltStatement.java
+++ b/src/main/java/com/firebolt/jdbc/statement/FireboltStatement.java
@@ -111,8 +111,7 @@ public class FireboltStatement extends JdbcBase implements Statement {
 					connection.addProperty(statementInfoWrapper.getParam());
 					log.debug("The property from the query {} was stored", runningStatementLabel);
 				} else {
-					Optional<ResultSet> currentRs = statementService.execute(statementInfoWrapper,
-							sessionProperties, queryTimeout, maxRows, maxFieldSize, isStandardSql, sessionProperties.isSystemEngine(), this);
+					Optional<ResultSet> currentRs = statementService.execute(statementInfoWrapper, sessionProperties, isStandardSql, this);
 					if (currentRs.isPresent()) {
 						resultSet = currentRs.get();
 						currentUpdateCount = -1; // Always -1 when returning a ResultSet

--- a/src/test/java/com/firebolt/jdbc/resultset/FireboltResultSetTest.java
+++ b/src/test/java/com/firebolt/jdbc/resultset/FireboltResultSetTest.java
@@ -679,6 +679,8 @@ class FireboltResultSetTest {
 	void shouldNotCloseStatementWhenNotCloseOnCompletion() throws SQLException {
 		when(fireboltStatement.isCloseOnCompletion()).thenReturn(false);
 		inputStream = getInputStreamWithCommonResponseExample();
+		when(fireboltStatement.getMaxRows()).thenReturn(1024);
+		when(fireboltStatement.getMaxFieldSize()).thenReturn(0);
 		resultSet = new FireboltResultSet(inputStream, "any_name", "array_db", 65535, fireboltStatement);
 		resultSet.close();
 		verifyNoMoreInteractions(fireboltStatement);

--- a/src/test/java/com/firebolt/jdbc/service/FireboltStatementServiceTest.java
+++ b/src/test/java/com/firebolt/jdbc/service/FireboltStatementServiceTest.java
@@ -43,9 +43,9 @@ class FireboltStatementServiceTest {
 			StatementInfoWrapper statementInfoWrapper = StatementUtil.parseToStatementInfoWrappers("SELECT 1").get(0);
 			FireboltProperties fireboltProperties = fireboltProperties("firebolt1", false);
 			FireboltStatementService fireboltStatementService = new FireboltStatementService(statementClient);
-
-			fireboltStatementService.execute(statementInfoWrapper, fireboltProperties, 10, -1, 0, true, false,
-					mock(FireboltStatement.class));
+			FireboltStatement statement = mock(FireboltStatement.class);
+			when(statement.getQueryTimeout()).thenReturn(10);
+			fireboltStatementService.execute(statementInfoWrapper, fireboltProperties, true, statement);
 			verify(statementClient).executeSqlStatement(statementInfoWrapper, fireboltProperties, false, 10, true);
 			Assertions.assertEquals(1, mocked.constructed().size());
 		}
@@ -57,8 +57,9 @@ class FireboltStatementServiceTest {
 			StatementInfoWrapper statementInfoWrapper = StatementUtil.parseToStatementInfoWrappers("SELECT 1").get(0);
 			FireboltProperties fireboltProperties = fireboltProperties("localhost", false);
 			FireboltStatementService fireboltStatementService = new FireboltStatementService(statementClient);
-			fireboltStatementService.execute(statementInfoWrapper, fireboltProperties, -1, 10, 0, true, false,
-					mock(FireboltStatement.class));
+			FireboltStatement statement = mock(FireboltStatement.class);
+			when(statement.getQueryTimeout()).thenReturn(-1);
+			fireboltStatementService.execute(statementInfoWrapper, fireboltProperties, true, statement);
 			Assertions.assertEquals(1, mocked.constructed().size());
 			verify(statementClient).executeSqlStatement(statementInfoWrapper, fireboltProperties, false, -1, true);
 		}
@@ -85,10 +86,11 @@ class FireboltStatementServiceTest {
 	void shouldExecuteQueryWithParametersForSystemEngine() throws SQLException {
 		try (MockedConstruction<FireboltResultSet> mocked = Mockito.mockConstruction(FireboltResultSet.class)) {
 			StatementInfoWrapper statementInfoWrapper = StatementUtil.parseToStatementInfoWrappers("SELECT 1").get(0);
-			FireboltProperties fireboltProperties = fireboltProperties("firebolt1", false);
+			FireboltProperties fireboltProperties = fireboltProperties("firebolt1", true);
 			FireboltStatementService fireboltStatementService = new FireboltStatementService(statementClient);
-			fireboltStatementService.execute(statementInfoWrapper, fireboltProperties, 10, 10, 0, true, true,
-					mock(FireboltStatement.class));
+			FireboltStatement statement = mock(FireboltStatement.class);
+			when(statement.getQueryTimeout()).thenReturn(10);
+			fireboltStatementService.execute(statementInfoWrapper, fireboltProperties, true, statement);
 			Assertions.assertEquals(1, mocked.constructed().size());
 			verify(statementClient).executeSqlStatement(statementInfoWrapper, fireboltProperties, true, 10, true);
 		}
@@ -99,11 +101,12 @@ class FireboltStatementServiceTest {
 		try (MockedConstruction<FireboltResultSet> mocked = Mockito.mockConstruction(FireboltResultSet.class)) {
 
 			StatementInfoWrapper statementInfoWrapper = StatementUtil.parseToStatementInfoWrappers("SELECT 1").get(0);
-			FireboltProperties fireboltProperties = fireboltProperties("localhost", false);
+			FireboltProperties fireboltProperties = fireboltProperties("localhost", true);
 
 			FireboltStatementService fireboltStatementService = new FireboltStatementService(statementClient);
-			fireboltStatementService.execute(statementInfoWrapper, fireboltProperties, -1, 0, 0, false, true,
-					mock(FireboltStatement.class));
+			FireboltStatement statement = mock(FireboltStatement.class);
+			when(statement.getQueryTimeout()).thenReturn(-1);
+			fireboltStatementService.execute(statementInfoWrapper, fireboltProperties, false, statement);
 			Assertions.assertEquals(1, mocked.constructed().size());
 			verify(statementClient).executeSqlStatement(statementInfoWrapper, fireboltProperties, true, -1, false);
 		}
@@ -116,8 +119,10 @@ class FireboltStatementServiceTest {
 		FireboltProperties fireboltProperties = fireboltProperties("localhost", false);
 
 		FireboltStatementService fireboltStatementService = new FireboltStatementService(statementClient);
+		FireboltStatement statement = mock(FireboltStatement.class);
+		when(statement.getQueryTimeout()).thenReturn(-1);
 		Assertions.assertEquals(Optional.empty(), fireboltStatementService.execute(statementInfoWrapper,
-				fireboltProperties, -1, 10, 0, true, false, mock(FireboltStatement.class)));
+				fireboltProperties, true, statement));
 		verify(statementClient).executeSqlStatement(statementInfoWrapper, fireboltProperties, false, -1, true);
 	}
 

--- a/src/test/java/com/firebolt/jdbc/statement/FireboltStatementTest.java
+++ b/src/test/java/com/firebolt/jdbc/statement/FireboltStatementTest.java
@@ -119,10 +119,8 @@ class FireboltStatementTest {
         FireboltConnection connection = mock(FireboltConnection.class);
         FireboltStatement fireboltStatement = new FireboltStatement(fireboltStatementService, fireboltProperties, connection);
 
-        when(fireboltStatementService.execute(any(), any(), anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any()))
-                .thenReturn(Optional.empty());
-        when(fireboltStatementService.execute(any(), any(), anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any()))
-                .thenReturn(Optional.of(rs));
+        when(fireboltStatementService.execute(any(), any(), anyBoolean(), any())).thenReturn(Optional.empty());
+        when(fireboltStatementService.execute(any(), any(), anyBoolean(), any())).thenReturn(Optional.of(rs));
         fireboltStatement.executeQuery("show database");
         fireboltStatement.close();
         verify(rs).close();
@@ -153,11 +151,9 @@ class FireboltStatementTest {
 
     private void shouldExecuteIfUpdateStatementWouldNotReturnAResultSet(CheckedBiFunction<Statement, String, Integer> executor) throws SQLException {
         try (FireboltStatement fireboltStatement = new FireboltStatement(fireboltStatementService, fireboltProperties, fireboltConnection)) {
-            when(fireboltStatementService.execute(any(), any(), anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any()))
-                    .thenReturn(Optional.empty());
+            when(fireboltStatementService.execute(any(), any(), anyBoolean(), any())).thenReturn(Optional.empty());
             assertEquals(0, executor.apply(fireboltStatement, "INSERT INTO cars(sales, name) VALUES (500, 'Ford')"));
-            verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(fireboltProperties),
-                    anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any());
+            verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(fireboltProperties),anyBoolean(), any());
             assertEquals("INSERT INTO cars(sales, name) VALUES (500, 'Ford')",
                     queryInfoWrapperArgumentCaptor.getValue().getSql());
             assertEquals(0, fireboltStatement.getUpdateCount());
@@ -178,7 +174,7 @@ class FireboltStatementTest {
         ResultSet rs = mock(FireboltResultSet.class);
         FireboltConnection connection = mock(FireboltConnection.class);
         FireboltStatement fireboltStatement = new FireboltStatement(fireboltStatementService, fireboltProperties, connection);
-        when(fireboltStatementService.execute(any(), any(), anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any())).thenReturn(Optional.of(rs));
+        when(fireboltStatementService.execute(any(), any(), anyBoolean(), any())).thenReturn(Optional.of(rs));
         assertTrue(executor.apply(fireboltStatement, "SELECT 1"));
         assertEquals(rs, fireboltStatement.getResultSet());
         assertEquals(-1, fireboltStatement.getUpdateCount());
@@ -194,8 +190,7 @@ class FireboltStatementTest {
         FireboltConnection connection = mock(FireboltConnection.class);
         FireboltStatement fireboltStatement = new FireboltStatement(fireboltStatementService, fireboltProperties, connection);
 
-        when(fireboltStatementService.execute(any(), any(), anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any()))
-                .thenReturn(Optional.of(rs)).thenReturn(Optional.of(rs2));
+        when(fireboltStatementService.execute(any(), any(), anyBoolean(), any())).thenReturn(Optional.of(rs)).thenReturn(Optional.of(rs2));
         fireboltStatement.execute("SELECT 1; SELECT 2;");
         assertEquals(rs, fireboltStatement.getResultSet());
         assertEquals(-1, fireboltStatement.getUpdateCount());
@@ -213,8 +208,7 @@ class FireboltStatementTest {
     void shouldCloseCurrentAndGetMoreResultWhenCallingGetMoreResultsWithCloseCurrentFlag() throws SQLException {
         FireboltConnection connection = mock(FireboltConnection.class);
         FireboltStatement fireboltStatement = new FireboltStatement(fireboltStatementService, fireboltProperties, connection);
-        when(fireboltStatementService.execute(any(), any(), anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any()))
-                .thenReturn(Optional.of(mock(FireboltResultSet.class)));
+        when(fireboltStatementService.execute(any(), any(), anyBoolean(), any())).thenReturn(Optional.of(mock(FireboltResultSet.class)));
         fireboltStatement.execute("SELECT 1; SELECT 2;");
         ResultSet resultSet = fireboltStatement.getResultSet();
         fireboltStatement.getMoreResults(CLOSE_CURRENT_RESULT);
@@ -225,9 +219,7 @@ class FireboltStatementTest {
     void shouldKeepCurrentAndGetMoreResultWhenCallingGetMoreResultsWithKeepCurrentResultFlag() throws SQLException {
         FireboltConnection connection = mock(FireboltConnection.class);
         FireboltStatement fireboltStatement = new FireboltStatement(fireboltStatementService, fireboltProperties, connection);
-        when(fireboltStatementService.execute(any(), any(), anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any()))
-                .thenReturn(Optional.of(mock(ResultSet.class)));
-
+        when(fireboltStatementService.execute(any(), any(), anyBoolean(), any())).thenReturn(Optional.of(mock(ResultSet.class)));
         fireboltStatement.execute("SELECT 1; SELECT 2;");
         ResultSet resultSet = fireboltStatement.getResultSet();
         fireboltStatement.getMoreResults(Statement.KEEP_CURRENT_RESULT);
@@ -242,7 +234,7 @@ class FireboltStatementTest {
         FireboltConnection connection = mock(FireboltConnection.class);
         FireboltStatement fireboltStatement = new FireboltStatement(fireboltStatementService, fireboltProperties, connection);
 
-        when(fireboltStatementService.execute(any(), any(), anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any()))
+        when(fireboltStatementService.execute(any(), any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(rs)).thenReturn(Optional.of(rs2)).thenReturn(Optional.of(rs3));
 
         fireboltStatement.execute("SELECT 1; SELECT 2; SELECT 3;");

--- a/src/test/java/com/firebolt/jdbc/statement/preparedstatement/FireboltPreparedStatementTest.java
+++ b/src/test/java/com/firebolt/jdbc/statement/preparedstatement/FireboltPreparedStatementTest.java
@@ -53,9 +53,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -121,8 +121,7 @@ class FireboltPreparedStatementTest {
 	void beforeEach() throws SQLException {
 		when(connection.getSessionProperties()).thenReturn(properties);
 		lenient().when(properties.getBufferSize()).thenReturn(10);
-		lenient().when(fireboltStatementService.execute(any(), any(), anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any()))
-				.thenReturn(Optional.empty());
+		lenient().when(fireboltStatementService.execute(any(), any(), anyBoolean(), any())).thenReturn(Optional.empty());
 	}
 
 	@AfterEach
@@ -165,9 +164,7 @@ class FireboltPreparedStatementTest {
 		statement.setArray(7, new FireboltArray(FireboltDataType.TEXT, new String[] {"sedan", "hatchback", "coupe"}));
 		statement.setBytes(8, "HarryFord".getBytes());
 		statement.execute();
-		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties),
-				anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any());
-
+		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties), anyBoolean(), any());
 		assertEquals("INSERT INTO cars (sales, make, model, minor_model, color, type, types, signature) VALUES (500,'Ford','FOCUS',NULL,NULL,'sedan',['sedan','hatchback','coupe'],E'\\x48\\x61\\x72\\x72\\x79\\x46\\x6f\\x72\\x64'::BYTEA)",
 				queryInfoWrapperArgumentCaptor.getValue().getSql());
 	}
@@ -185,9 +182,7 @@ class FireboltPreparedStatementTest {
 		statement.setArray(7, new FireboltArray(FireboltDataType.TEXT, new String[] {"sedan", "hatchback", "coupe"}));
 		statement.setBytes(8, null);
 		statement.execute();
-		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties),
-				anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any());
-
+		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties), anyBoolean(), any());
 		assertEquals("INSERT INTO cars (sales, make, model, minor_model, color, type, types, signature) VALUES (500,'Ford','FOCUS',NULL,NULL,'sedan',['sedan','hatchback','coupe'],NULL)",
 				queryInfoWrapperArgumentCaptor.getValue().getSql());
 	}
@@ -204,9 +199,7 @@ class FireboltPreparedStatementTest {
 		statement.setObject(2, "Tesla");
 		statement.addBatch();
 		statement.executeBatch();
-		verify(fireboltStatementService, times(2)).execute(queryInfoWrapperArgumentCaptor.capture(),
-				eq(properties), anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any());
-
+		verify(fireboltStatementService, times(2)).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties), anyBoolean(), any());
 		assertEquals("INSERT INTO cars (sales, make) VALUES (150,'Ford')",
 				queryInfoWrapperArgumentCaptor.getAllValues().get(0).getSql());
 		assertEquals("INSERT INTO cars (sales, make) VALUES (300,'Tesla')",
@@ -236,8 +229,7 @@ class FireboltPreparedStatementTest {
 		String expectedSql = "INSERT INTO cars (model ,sales, make) VALUES ('?',' ?','(?:^|[^\\\\p{L}\\\\p{N}])(?i)(phone)(?:[^\\\\p{L}\\\\p{N}]|$)')";
 
 		statement.execute();
-		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties),
-				anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any());
+		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties), anyBoolean(), any());
 		assertEquals(expectedSql, queryInfoWrapperArgumentCaptor.getValue().getSql());
 	}
 
@@ -270,8 +262,7 @@ class FireboltPreparedStatementTest {
 		statement.setNull(2, 0);
 		statement.execute();
 
-		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties),
-				anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any());
+		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties), anyBoolean(), any());
 		assertEquals("INSERT INTO cars (sales, make) VALUES (NULL,NULL)",
 				queryInfoWrapperArgumentCaptor.getValue().getSql());
 	}
@@ -283,8 +274,7 @@ class FireboltPreparedStatementTest {
 		statement.setBoolean(1, true);
 		statement.execute();
 
-		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties),
-				anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any());
+		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties), anyBoolean(), any());
 		assertEquals("INSERT INTO cars(available) VALUES (1)", queryInfoWrapperArgumentCaptor.getValue().getSql());
 	}
 
@@ -309,8 +299,7 @@ class FireboltPreparedStatementTest {
 		statement.setInt(1, 50);
 		statement.execute();
 
-		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties),
-				anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any());
+		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties), anyBoolean(), any());
 	}
 
 	@Test
@@ -320,8 +309,7 @@ class FireboltPreparedStatementTest {
 		statement.setLong(1, 50L);
 		statement.execute();
 
-		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties),
-				anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any());
+		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties), anyBoolean(), any());
 		assertEquals("INSERT INTO cars(price) VALUES (50)", queryInfoWrapperArgumentCaptor.getValue().getSql());
 	}
 
@@ -332,9 +320,7 @@ class FireboltPreparedStatementTest {
 		statement.setFloat(1, 5.5F);
 		statement.execute();
 
-		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties),
-				anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any());
-
+		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties), anyBoolean(), any());
 		assertEquals("INSERT INTO cars(price) VALUES (5.5)", queryInfoWrapperArgumentCaptor.getValue().getSql());
 	}
 
@@ -345,8 +331,7 @@ class FireboltPreparedStatementTest {
 		statement.setDouble(1, 5.5);
 		statement.execute();
 
-		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties),
-				anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any());
+		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties), anyBoolean(), any());
 	}
 
 	@Test
@@ -356,8 +341,7 @@ class FireboltPreparedStatementTest {
 		statement.setBigDecimal(1, new BigDecimal("555555555555.55555555"));
 		statement.execute();
 
-		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties),
-				anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any());
+		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties), anyBoolean(), any());
 		assertEquals("INSERT INTO cars(price) VALUES (555555555555.55555555)",
 				queryInfoWrapperArgumentCaptor.getValue().getSql());
 	}
@@ -370,8 +354,7 @@ class FireboltPreparedStatementTest {
 		statement.setDate(1, new Date(1564527600000L));
 		statement.execute();
 
-		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties),
-				anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any());
+		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties), anyBoolean(), any());
 		assertEquals("INSERT INTO cars(release_date) VALUES ('2019-07-31')",
 				queryInfoWrapperArgumentCaptor.getValue().getSql());
 	}
@@ -384,9 +367,7 @@ class FireboltPreparedStatementTest {
 		statement.setTimestamp(1, new Timestamp(1564571713000L));
 		statement.execute();
 
-		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties),
-				anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any());
-
+		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties), anyBoolean(), any());
 		assertEquals("INSERT INTO cars(release_date) VALUES ('2019-07-31 12:15:13')",
 				queryInfoWrapperArgumentCaptor.getValue().getSql());
 	}
@@ -409,9 +390,7 @@ class FireboltPreparedStatementTest {
 
 		statement.execute();
 
-		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties),
-				anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any());
-
+		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties), anyBoolean(), any());
 		assertEquals(
 				"INSERT INTO cars(timestamp, date, float, long, big_decimal, null, boolean, int) VALUES ('2019-07-31 12:15:13','2019-07-31',5.5,5,555555555555.55555555,NULL,1,5)",
 				queryInfoWrapperArgumentCaptor.getValue().getSql());
@@ -435,8 +414,7 @@ class FireboltPreparedStatementTest {
 
 		statement.execute();
 
-		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties),
-				anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any());
+		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties), anyBoolean(), any());
 
 		assertEquals(
 				"INSERT INTO cars(timestamp, date, float, long, big_decimal, null, boolean, int) VALUES ('2019-07-31 12:15:13','2019-07-31',5.5,5,555555555555.55555555,NULL,1,5)",
@@ -506,8 +484,7 @@ class FireboltPreparedStatementTest {
 			statement.setObject(1, value, type, scale);
 		}
 		statement.execute();
-		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties),
-				anyInt(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any());
+		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties), anyBoolean(), any());
 
 		assertEquals(format("INSERT INTO data (column) VALUES (%s)", expected), queryInfoWrapperArgumentCaptor.getValue().getSql());
 	}


### PR DESCRIPTION
number of parameters is reduced because some of them can be retrieved from passed statement

(*) most of change here are in test mockup. The real change is in `FireboltStatementService.execute()` and in place where this method is called. 