### PR TITLE
added tests of getMaxStatementLength() and getMaxRowSize() that retur…

### DIFF
--- a/src/main/java/com/firebolt/jdbc/metadata/FireboltDatabaseMetadata.java
+++ b/src/main/java/com/firebolt/jdbc/metadata/FireboltDatabaseMetadata.java
@@ -2,8 +2,6 @@ package com.firebolt.jdbc.metadata;
 
 import com.firebolt.jdbc.GenericWrapper;
 import com.firebolt.jdbc.QueryResult;
-import com.firebolt.jdbc.annotation.ExcludeFromJacocoGeneratedReport;
-import com.firebolt.jdbc.annotation.NotImplemented;
 import com.firebolt.jdbc.connection.FireboltConnection;
 import com.firebolt.jdbc.resultset.FireboltResultSet;
 import com.firebolt.jdbc.resultset.column.Column;
@@ -958,21 +956,16 @@ public class FireboltDatabaseMetadata implements DatabaseMetaData, GenericWrappe
 	}
 
 	@Override
-	@ExcludeFromJacocoGeneratedReport
-	@NotImplemented
 	public int getMaxRowSize() {
 		return 0;
 	}
 
 	@Override
-	@ExcludeFromJacocoGeneratedReport
 	public boolean doesMaxRowSizeIncludeBlobs() {
-		return false;
+		return true;
 	}
 
 	@Override
-	@ExcludeFromJacocoGeneratedReport
-	@NotImplemented
 	public int getMaxStatementLength() {
 		return 0;
 	}

--- a/src/test/java/com/firebolt/jdbc/metadata/FireboltDatabaseMetadataTest.java
+++ b/src/test/java/com/firebolt/jdbc/metadata/FireboltDatabaseMetadataTest.java
@@ -630,6 +630,9 @@ class FireboltDatabaseMetadataTest {
 		assertEquals(0, fireboltDatabaseMetadata.getMaxStatements());
 		assertEquals(63, fireboltDatabaseMetadata.getMaxUserNameLength());
 		assertEquals(0, fireboltDatabaseMetadata.getMaxTablesInSelect());
+		assertEquals(0, fireboltDatabaseMetadata.getMaxRowSize());
+		assertEquals(0, fireboltDatabaseMetadata.getMaxStatementLength());
+		assertTrue(fireboltDatabaseMetadata.doesMaxRowSizeIncludeBlobs());
 	}
 
 	@Test


### PR DESCRIPTION
getMaxStatementLength() and getMaxRowSize() that return 0 that means that these parameters are unlimited. In fact they are limited by the engine memory only but not by any limits in code. 