### PR TITLE
build: remove signing of a build artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ plugins {
     id "org.sonarqube" version "5.0.0.4638"
     id 'maven-publish'
     id 'com.github.johnrengelman.shadow' version '8.0.0'
-    id 'signing'
 }
 
 group 'io.firebolt'
@@ -333,11 +332,6 @@ task generateJavadoc(type: Javadoc) {
         links = ['https://docs.oracle.com/javase/8/docs/api/']
     }
     options.addStringOption('Xdoclint:none', '-quiet')
-}
-
-
-signing {
-    sign publishing.publications
 }
 
 if (hasProperty('buildScan')) {


### PR DESCRIPTION
Removed signing of a build artifact since we don't have a key now to sign with