### PR TITLE
fix: Fir 35049 dont reset engine autostop with service queries in drivers for jdbc

### DIFF
--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionTest.java
@@ -336,6 +336,7 @@ abstract class FireboltConnectionTest {
 			verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(),
 					propertiesArgumentCaptor.capture(), any());
 			assertEquals(List.of("SELECT 1"), queryInfoWrapperArgumentCaptor.getAllValues().stream().map(StatementInfoWrapper::getSql).collect(toList()));
+			assertEquals(Map.of("auto_start_stop_control", "ignore"), propertiesArgumentCaptor.getValue().getAdditionalProperties());
 		}
 	}
 


### PR DESCRIPTION
Added auto_start_stop_control=ignore parameter to isValid call of JDBC connection