### PR TITLE
refactor: Fir 35469 remove account resolve endpoint from jdbc

### DIFF
--- a/src/integrationTest/java/integration/tests/SystemEngineTest.java
+++ b/src/integrationTest/java/integration/tests/SystemEngineTest.java
@@ -136,7 +136,8 @@ public class SystemEngineTest extends IntegrationTest {
 				}
 				FireboltException e = assertThrows(FireboltException.class, () -> systemConnection.createStatement().executeQuery("select count(*) from dummy"));
 				String actualErrorMessage = e.getErrorMessageFromServer().replaceAll("\r?\n", "");
-				assertTrue(expectedErrorMessages.contains(actualErrorMessage), "Unexpected error message: " + actualErrorMessage);
+				// Check that at least  one error message from expectedErrorMessages is contained in the actual error message
+				assertTrue(expectedErrorMessages.stream().anyMatch(actualErrorMessage::contains), "Unexpected error message: " + actualErrorMessage);
 			} finally {
 				try {
 					customConnection.createStatement().executeUpdate("DROP TABLE dummy");

--- a/src/main/java/com/firebolt/jdbc/client/account/FireboltAccountRetriever.java
+++ b/src/main/java/com/firebolt/jdbc/client/account/FireboltAccountRetriever.java
@@ -15,22 +15,20 @@ import static java.lang.String.format;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 
 public class FireboltAccountRetriever<T> extends FireboltClient implements CacheListener {
-    private static final String URL = "https://%s/web/v3/account/%s/%s";
+    private static final String URL = "https://%s/web/v3/account/%s/engineUrl";
     private final String host;
-    private final String path;
     private final Class<T> type;
     private static final Map<String, Object> valueCache = new ConcurrentHashMap<>();
 
-    public FireboltAccountRetriever(OkHttpClient httpClient, FireboltConnection connection, String customDrivers, String customClients, String host, String path, Class<T> type) {
+    public FireboltAccountRetriever(OkHttpClient httpClient, FireboltConnection connection, String customDrivers, String customClients, String host, Class<T> type) {
         super(httpClient, connection, customDrivers, customClients);
         this.host = host;
-        this.path = path;
         this.type = type;
     }
 
     public T retrieve(String accessToken, String accountName) throws SQLException {
         try {
-            String url = format(URL, host, accountName, path);
+            String url = format(URL, host, accountName);
             @SuppressWarnings("unchecked")
             T value = (T)valueCache.get(url);
             if (value == null) {
@@ -39,7 +37,7 @@ public class FireboltAccountRetriever<T> extends FireboltClient implements Cache
             }
             return value;
         } catch (IOException e) {
-            throw new FireboltException(String.format("Failed to get %s url for account %s: %s", path, accountName, e.getMessage()), e);
+            throw new FireboltException(String.format("Failed to get engine url for account %s: %s", accountName, e.getMessage()), e);
         }
     }
 

--- a/src/main/java/com/firebolt/jdbc/client/query/StatementClientImpl.java
+++ b/src/main/java/com/firebolt/jdbc/client/query/StatementClientImpl.java
@@ -314,9 +314,12 @@ public class StatementClientImpl extends FireboltClient implements StatementClie
 			}
 		} else {
 			if (connection.getInfraVersion() >= 2) {
+				String engine = fireboltProperties.getEngine();
 				if (accountId != null) {
 					params.put(FireboltQueryParameterKey.ACCOUNT_ID.getKey(), accountId);
-					params.put(FireboltQueryParameterKey.ENGINE.getKey(), fireboltProperties.getEngine());
+				}
+				if (engine != null) {
+					params.put(FireboltQueryParameterKey.ENGINE.getKey(), engine);
 				}
 				params.put(FireboltQueryParameterKey.QUERY_LABEL.getKey(), statementInfoWrapper.getLabel()); //QUERY_LABEL
 			}

--- a/src/test/java/com/firebolt/jdbc/client/gateway/FireboltGatewayUrlClientTest.java
+++ b/src/test/java/com/firebolt/jdbc/client/gateway/FireboltGatewayUrlClientTest.java
@@ -65,13 +65,11 @@ class FireboltAccountRetrieverTest {
 	private FireboltConnection fireboltConnection;
 
     private FireboltAccountRetriever<GatewayUrlResponse> fireboltGatewayUrlClient;
-    private FireboltAccountRetriever<FireboltAccount> fireboltAccountIdResolver;
 
 
     @BeforeEach
     void setUp() {
-        fireboltGatewayUrlClient = new FireboltAccountRetriever<>(httpClient, fireboltConnection, null, null, "test-firebolt.io", "engineUrl", GatewayUrlResponse.class);
-        fireboltAccountIdResolver = new FireboltAccountRetriever<>(httpClient, fireboltConnection, null, null, "test-firebolt.io", "resolve", FireboltAccount.class);
+        fireboltGatewayUrlClient = new FireboltAccountRetriever<>(httpClient, fireboltConnection, null, null, "test-firebolt.io", GatewayUrlResponse.class);
     }
 
 	@Test
@@ -80,21 +78,6 @@ class FireboltAccountRetrieverTest {
         injectMockedResponse(httpClient, HTTP_OK, format("{\"engineUrl\":  \"%s\"}", engineUrl));
         assertEquals(engineUrl, fireboltGatewayUrlClient.retrieve("access_token", "account").getEngineUrl());
 	}
-
-    @Test
-    void shouldGetAccountId() throws SQLException, IOException {
-        fireboltAccountIdResolver.cleanup();
-        FireboltAccount account = new FireboltAccount("12345", "central", 2);
-        injectMockedResponse(httpClient, HTTP_OK, "{\"id\": \"12345\", \"region\":\"central\", \"infraVersion\":2}");
-        assertEquals(account, fireboltAccountIdResolver.retrieve("access_token", "account"));
-        Mockito.verify(httpClient, times(1)).newCall(any());
-        // Do this again. The response is cached, so the invocation count will remain 1
-        assertEquals(account, fireboltAccountIdResolver.retrieve("access_token", "account"));
-        // now clean the cache and call resolve() again. The invocation counter will be incremented.
-        fireboltAccountIdResolver.cleanup();
-        assertEquals(account, fireboltAccountIdResolver.retrieve("access_token", "account"));
-        Mockito.verify(httpClient, times(2)).newCall(any());
-    }
 
     @Test
     void shouldRuntimeExceptionUponRuntimeException() {
@@ -107,20 +90,19 @@ class FireboltAccountRetrieverTest {
         Call call = mock(Call.class);
         when(httpClient.newCall(any())).thenReturn(call);
         when(call.execute()).thenThrow(new IOException("io error"));
-        assertEquals("Failed to get engineUrl url for account acc: io error", assertThrows(FireboltException.class, () -> fireboltGatewayUrlClient.retrieve("token", "acc")).getMessage());
+        assertEquals("Failed to get engine url for account acc: io error", assertThrows(FireboltException.class, () -> fireboltGatewayUrlClient.retrieve("token", "acc")).getMessage());
     }
 
     @ParameterizedTest(name = "{0}:{1}")
     @CsvSource({
-            "resolve, com.firebolt.jdbc.client.account.FireboltAccount, {}, JSONObject[\"id\"] not found.",
-            "engineUrl, com.firebolt.jdbc.client.gateway.GatewayUrlResponse, {}, JSONObject[\"engineUrl\"] not found."
+            "com.firebolt.jdbc.client.gateway.GatewayUrlResponse, {}, JSONObject[\"engineUrl\"] not found."
     })
-    <T> void shouldThrowFireboltExceptionUponWrongJsonFormat(String path, Class<T> clazz, String json, String expectedErrorMessage) throws IOException {
-        FireboltAccountRetriever<T> fireboltAccountIdResolver = mockAccountRetriever(path, clazz, json);
-        assertEquals(format("Failed to get %s url for account acc: %s", path, expectedErrorMessage), assertThrows(FireboltException.class, () -> fireboltAccountIdResolver.retrieve("token", "acc")).getMessage());
+    <T> void shouldThrowFireboltExceptionUponWrongJsonFormat(Class<T> clazz, String json, String expectedErrorMessage) throws IOException {
+        FireboltAccountRetriever<T> fireboltAccountIdResolver = mockAccountRetriever(clazz, json);
+        assertEquals(format("Failed to get engine url for account acc: %s", expectedErrorMessage), assertThrows(FireboltException.class, () -> fireboltAccountIdResolver.retrieve("token", "acc")).getMessage());
     }
 
-    private <T> FireboltAccountRetriever<T> mockAccountRetriever(String path, Class<T> clazz, String json) throws IOException {
+    private <T> FireboltAccountRetriever<T> mockAccountRetriever(Class<T> clazz, String json) throws IOException {
         try (Response response = mock(Response.class)) {
             when(response.code()).thenReturn(200);
             ResponseBody responseBody = mock(ResponseBody.class);
@@ -130,7 +112,7 @@ class FireboltAccountRetrieverTest {
             Call call = mock();
             when(call.execute()).thenReturn(response);
             when(okHttpClient.newCall(any())).thenReturn(call);
-            return new FireboltAccountRetriever<>(okHttpClient, mock(), null, null, "test-firebolt.io", path, clazz);
+            return new FireboltAccountRetriever<>(okHttpClient, mock(), null, null, "test-firebolt.io", clazz);
         }
     }
 
@@ -165,7 +147,6 @@ class FireboltAccountRetrieverTest {
     })
     void testFailedAccountDataRetrieving(int statusCode, String errorMessageTemplate) throws IOException {
         injectMockedResponse(httpClient, statusCode, null);
-        assertErrorMessage(fireboltAccountIdResolver, "one", format(errorMessageTemplate, "one", "resolve"));
         assertErrorMessage(fireboltGatewayUrlClient, "two", format(errorMessageTemplate, "two", "engineUrl"));
     }
 


### PR DESCRIPTION
Removed account resolve call. Still leaving infraVersion variable in place since it's currently used to distinguish between fb1.0 and 2.0. Refactoring it out would be a much bigger effort