### PR TITLE
Fir 37710 jdbc validate connection against system engine

### DIFF
--- a/src/integrationTest/java/integration/ConnectionInfo.java
+++ b/src/integrationTest/java/integration/ConnectionInfo.java
@@ -1,5 +1,7 @@
 package integration;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -20,6 +22,7 @@ public class ConnectionInfo {
 	private final String account;
 	private final String engine;
 	private final String api;
+	private final Map<String, String> extra;
 	private final Supplier<String> jdbcUrlSupplier;
 
 	private ConnectionInfo() {
@@ -35,6 +38,10 @@ public class ConnectionInfo {
 	}
 
 	public ConnectionInfo(String principal, String secret, String env, String database, String account, String engine, String api) {
+		this(principal, secret, env, database, account, engine, api, new HashMap<>());
+	}
+
+	public ConnectionInfo(String principal, String secret, String env, String database, String account, String engine, String api, Map<String, String> extra) {
 		this.principal = principal;
 		this.secret = secret;
 		this.env = env;
@@ -42,6 +49,7 @@ public class ConnectionInfo {
 		this.account = account;
 		this.engine = engine;
 		this.api = api;
+		this.extra = extra;
 		jdbcUrlSupplier = api == null ? this::toJdbcUrl2 : this::toJdbcUrl1;
 	}
 
@@ -97,7 +105,10 @@ public class ConnectionInfo {
 	}
 
 	private String toJdbcUrl2() {
-		String params = Stream.of(param("env", env), param("engine", engine), param("account", account)).filter(Objects::nonNull).collect(joining("&"));
+		String params = Stream.concat(
+				Stream.of(param("env", env), param("engine", engine), param("account", account)),
+				extra.entrySet().stream().map(e -> param(e.getKey(), e.getValue()))
+		).filter(Objects::nonNull).collect(joining("&"));
 		if (!params.isEmpty()) {
 			params = "?" + params;
 		}

--- a/src/integrationTest/java/integration/IntegrationTest.java
+++ b/src/integrationTest/java/integration/IntegrationTest.java
@@ -13,6 +13,8 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.firebolt.jdbc.connection.FireboltConnectionUserPassword.SYSTEM_ENGINE_NAME;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -37,9 +39,13 @@ public abstract class IntegrationTest {
 	}
 
 	protected Connection createConnection(String engine) throws SQLException {
+		return createConnection(engine, new HashMap<>());
+	}
+
+	protected Connection createConnection(String engine, Map<String, String> extra) throws SQLException {
 		ConnectionInfo current = integration.ConnectionInfo.getInstance();
 		ConnectionInfo updated = new ConnectionInfo(current.getPrincipal(), current.getSecret(),
-				current.getEnv(), current.getDatabase(), current.getAccount(), engine, current.getApi());
+				current.getEnv(), current.getDatabase(), current.getAccount(), engine, current.getApi(), extra);
 		return DriverManager.getConnection(updated.toJdbcUrl(),
 				integration.ConnectionInfo.getInstance().getPrincipal(),
 				integration.ConnectionInfo.getInstance().getSecret());

--- a/src/integrationTest/java/integration/tests/ConnectionTest.java
+++ b/src/integrationTest/java/integration/tests/ConnectionTest.java
@@ -141,6 +141,7 @@ class ConnectionTest extends IntegrationTest {
     }
 
     @Test
+    @Tag("v2")
     void validatesOnSystemEngineIfParameterProvided() throws SQLException {
         try (Connection systemConnection = createConnection(null)) {
             String engineName = integration.ConnectionInfo.getInstance().getEngine() + "_validate_test";

--- a/src/integrationTest/java/integration/tests/ConnectionTest.java
+++ b/src/integrationTest/java/integration/tests/ConnectionTest.java
@@ -19,6 +19,7 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Map;
 
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -137,6 +138,37 @@ class ConnectionTest extends IntegrationTest {
             assertTrue(rs.next());
             assertNotNull(rs.getObject(1));
         }
+    }
+
+    @Test
+    void validatesOnSystemEngineIfParameterProvided() throws SQLException {
+        try (Connection systemConnection = createConnection(null)) {
+            String engineName = integration.ConnectionInfo.getInstance().getEngine() + "_validate_test";
+            try (Statement systemStatement = systemConnection.createStatement()) {
+                systemStatement.executeUpdate(format("CREATE ENGINE %s WITH INITIALLY_STOPPED=true", engineName));
+            }
+            try (Connection connection = createConnection(engineName, Map.of("validate_on_system_engine", "true"))) {
+                try (Statement systemStatement = systemConnection.createStatement()) {
+                    ResultSet rs = systemStatement.executeQuery(
+                            format("SELECT status FROM information_schema.engines WHERE engine_name='%s'", engineName));
+                    assertTrue(rs.next());
+                    assertEquals("STOPPED", rs.getString(1));
+                }
+                assertTrue(connection.isValid(500));
+                // After validation the engine should still be stopped
+                try (Statement systemStatement = systemConnection.createStatement()) {
+                    ResultSet rs = systemStatement.executeQuery(
+                            format("SELECT status FROM information_schema.engines WHERE engine_name='%s'", engineName));
+                    assertTrue(rs.next());
+                    assertEquals("STOPPED", rs.getString(1));
+                }
+            } finally {
+                try (Statement systemStatement = systemConnection.createStatement()) {
+                    systemStatement.executeUpdate(format("DROP ENGINE %s", engineName));
+                }
+            }
+        }
+
     }
 
     void unsuccessfulConnect(boolean useDatabase, boolean useEngine) throws SQLException {

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnection.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnection.java
@@ -427,9 +427,7 @@ public abstract class FireboltConnection extends JdbcBase implements Connection,
 			return false;
 		}
 		try {
-			if (!loginProperties.isSystemEngine()) {
-				validateConnection(getSessionProperties(), true, true);
-			}
+			validateConnection(getSessionProperties(), true, true);
 			return true;
 		} catch (Exception e) {
 			return false;

--- a/src/main/java/com/firebolt/jdbc/connection/settings/FireboltProperties.java
+++ b/src/main/java/com/firebolt/jdbc/connection/settings/FireboltProperties.java
@@ -75,6 +75,7 @@ public class FireboltProperties {
 	private final String userDrivers;
 	private final String userClients;
 	private final String accessToken;
+	private final boolean validateOnSystemEngine;
 	@Builder.Default
 	private Map<String, String> initialAdditionalProperties = new HashMap<>();
 	@Builder.Default
@@ -110,6 +111,7 @@ public class FireboltProperties {
 		String configuredEnvironment = getSetting(properties, FireboltSessionProperty.ENVIRONMENT);
 		userDrivers = getSetting(properties, FireboltSessionProperty.USER_DRIVERS);
 		userClients = getSetting(properties, FireboltSessionProperty.USER_CLIENTS);
+		validateOnSystemEngine = getSetting(properties, FireboltSessionProperty.VALIDATE_ON_SYSTEM_ENGINE);
 
 		environment = getEnvironment(configuredEnvironment, properties);
 		host = getHost(configuredEnvironment, properties);

--- a/src/main/java/com/firebolt/jdbc/connection/settings/FireboltSessionProperty.java
+++ b/src/main/java/com/firebolt/jdbc/connection/settings/FireboltSessionProperty.java
@@ -67,6 +67,8 @@ public enum FireboltSessionProperty {
 	USER_CLIENTS("user_clients", null, String.class, "user clients", FireboltProperties::getUserClients),
 	ACCESS_TOKEN("access_token", null, String.class, "access token", p -> "***"),
 	ENVIRONMENT("environment", "app", String.class, "Firebolt environment", FireboltProperties::getEnvironment, "env"),
+	VALIDATE_ON_SYSTEM_ENGINE("validate_on_system_engine", false, Boolean.class,
+			"Whether to validate the connection on the system engine or not. Not validated by default", FireboltProperties::isValidateOnSystemEngine),
 	// We keep all the deprecated properties to ensure backward compatibility - but
 	// they do not have any effect.
 	@Deprecated

--- a/src/main/java/com/firebolt/jdbc/connection/settings/FireboltSessionProperty.java
+++ b/src/main/java/com/firebolt/jdbc/connection/settings/FireboltSessionProperty.java
@@ -68,7 +68,8 @@ public enum FireboltSessionProperty {
 	ACCESS_TOKEN("access_token", null, String.class, "access token", p -> "***"),
 	ENVIRONMENT("environment", "app", String.class, "Firebolt environment", FireboltProperties::getEnvironment, "env"),
 	VALIDATE_ON_SYSTEM_ENGINE("validate_on_system_engine", false, Boolean.class,
-			"Whether to validate the connection on the system engine or not. Not validated by default", FireboltProperties::isValidateOnSystemEngine),
+			"Whether to validate the connection on the system engine or not. By default validates on an engine currently connected.",
+			FireboltProperties::isValidateOnSystemEngine),
 	// We keep all the deprecated properties to ensure backward compatibility - but
 	// they do not have any effect.
 	@Deprecated

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
@@ -40,15 +40,6 @@ class FireboltConnectionServiceSecretTest extends FireboltConnectionTest {
     }
 
     @Test
-    void shouldNotValidateConnectionWhenCallingIsValidWhenUsingSystemEngine() throws SQLException {
-        Properties propertiesWithSystemEngine = new Properties(connectionProperties);
-        try (FireboltConnection fireboltConnection = createConnection(SYSTEM_ENGINE_URL, propertiesWithSystemEngine)) {
-            fireboltConnection.isValid(500);
-            verifyNoInteractions(fireboltStatementService);
-        }
-    }
-
-    @Test
     void shouldNotGetEngineUrlOrDefaultEngineUrlWhenUsingSystemEngine() throws SQLException {
         connectionProperties.put("database", "my_db");
         when(fireboltGatewayUrlService.getUrl(any(), any())).thenReturn("http://my_endpoint");

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionTest.java
@@ -368,7 +368,7 @@ abstract class FireboltConnectionTest {
 					propertiesArgumentCaptor.capture(), any());
 			assertEquals(List.of("SELECT 1"), queryInfoWrapperArgumentCaptor.getAllValues().stream().map(StatementInfoWrapper::getSql).collect(toList()));
 			assertEquals(Map.of("auto_start_stop_control", "ignore"), propertiesArgumentCaptor.getValue().getAdditionalProperties());
-			assertEquals(SYSTEM_ENGINE_NAME, propertiesArgumentCaptor.getValue().getEngine());
+			assertEquals(null, propertiesArgumentCaptor.getValue().getEngine());
 			assertTrue(propertiesArgumentCaptor.getValue().isSystemEngine());
 		}
 	}

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionTest.java
@@ -709,5 +709,16 @@ abstract class FireboltConnectionTest {
 		}
 	}
 
+	@Test
+	void shouldValidateOnUserEngineByDefault() throws SQLException {
+		try (FireboltConnection fireboltConnection = createConnection(URL, connectionProperties)) {
+			assertEquals("false", fireboltConnection.getClientInfo().get("validate_on_system_engine"));
+		}
+		connectionProperties.put("validate_on_system_engine", "true");
+		try (FireboltConnection fireboltConnection = createConnection(URL, connectionProperties)) {
+			assertEquals("true", fireboltConnection.getClientInfo().get("validate_on_system_engine"));
+		}
+	}
+
 	protected abstract FireboltConnection createConnection(String url, Properties props) throws SQLException;
 }

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionUserPasswordTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionUserPasswordTest.java
@@ -31,15 +31,6 @@ class FireboltConnectionUserPasswordTest extends FireboltConnectionTest {
     }
 
     @Test
-    void shouldNotValidateConnectionWhenCallingIsValidWhenUsingSystemEngine() throws SQLException {
-        Properties propertiesWithSystemEngine = new Properties(connectionProperties);
-        try (FireboltConnection fireboltConnection = createConnection(SYSTEM_ENGINE_URL, propertiesWithSystemEngine)) {
-            fireboltConnection.isValid(500);
-            verifyNoInteractions(fireboltStatementService);
-        }
-    }
-
-    @Test
     void shouldNotGetEngineUrlOrDefaultEngineUrlWhenUsingSystemEngine() throws SQLException {
         connectionProperties.put("database", "my_db");
         try (FireboltConnection connection = createConnection(SYSTEM_ENGINE_URL, connectionProperties)) {

--- a/src/test/java/com/firebolt/jdbc/connection/settings/FireboltPropertiesTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/settings/FireboltPropertiesTest.java
@@ -48,6 +48,7 @@ class FireboltPropertiesTest {
 		properties.put("path", "example");
 		properties.put("someCustomProperties", "custom_value");
 		properties.put("compress", "1");
+		properties.put("validate_on_system_engine", "true");
 
 		Map<String, String> customProperties = new HashMap<>();
 		customProperties.put("someCustomProperties", "custom_value");
@@ -57,7 +58,8 @@ class FireboltPropertiesTest {
 				.port(443).principal(null).secret(null).host("myDummyHost").ssl(true).systemEngine(false)
 				.initialAdditionalProperties(customProperties).keepAliveTimeoutMillis(300000)
 				.maxConnectionsTotal(300).maxRetries(3).socketTimeoutMillis(20).connectionTimeoutMillis(60000)
-				.tcpKeepInterval(30).tcpKeepIdle(60).tcpKeepCount(10).environment("app").build();
+				.tcpKeepInterval(30).tcpKeepIdle(60).tcpKeepCount(10).environment("app").validateOnSystemEngine(true)
+				.build();
 		assertEquals(expectedDefaultProperties, new FireboltProperties(properties));
 	}
 


### PR DESCRIPTION
Improvements for isValid method:
- FIR-37621 run validation for a system engine as well
- add a connection property `validate_on_system_engine`, which forces a connection to run isValid on a system engine even if it's connected to a user engine