### PR TITLE
ci: Use GITHUB_TOKEN secret in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         file: ${{ needs.build.outputs.uber-jar }}
+        tags: true
         draft: false
     - name: Deploy to Maven Central repository
       run: ./gradlew publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         name: ${{ needs.build.outputs.sources-jar }}
     - uses: xresloader/upload-to-github-release@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         file: ${{ needs.build.outputs.uber-jar }}
         tags: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         file: ${{ needs.build.outputs.uber-jar }}
-        tags: true
         draft: false
     - name: Deploy to Maven Central repository
       run: ./gradlew publish


### PR DESCRIPTION
Fixing release CI since PAT has expired and looks like we don't need it.