### PR TITLE
test: relax version checks

### DIFF
--- a/src/test/java/com/firebolt/FireboltDriverTest.java
+++ b/src/test/java/com/firebolt/FireboltDriverTest.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -93,7 +94,9 @@ class FireboltDriverTest {
 	void version() {
 		FireboltDriver fireboltDriver = new FireboltDriver();
 		assertEquals(3, fireboltDriver.getMajorVersion());
-		assertEquals(5, fireboltDriver.getMinorVersion());
+		int minorVersion = fireboltDriver.getMinorVersion();
+		// Sanity check for minor version
+		assertTrue(minorVersion >= 0 && minorVersion < 100);
 	}
 
 	@ParameterizedTest

--- a/src/test/java/com/firebolt/jdbc/metadata/FireboltDatabaseMetadataTest.java
+++ b/src/test/java/com/firebolt/jdbc/metadata/FireboltDatabaseMetadataTest.java
@@ -356,12 +356,13 @@ class FireboltDatabaseMetadataTest {
 
 	@Test
 	void shouldGetDriverMinorVersion() {
-		assertEquals(5, fireboltDatabaseMetadata.getDriverMinorVersion());
+		int minorVersion = fireboltDatabaseMetadata.getDriverMinorVersion();
+		assertTrue(minorVersion >= 0 && minorVersion < 100);
 	}
 
 	@Test
 	void shouldGetDriverVersion() throws SQLException {
-		assertEquals("3.5.0", fireboltDatabaseMetadata.getDriverVersion());
+		assertTrue(fireboltDatabaseMetadata.getDriverVersion().matches("3\\.\\d+\\.\\d+"));
 	}
 
 	@Test

--- a/src/test/java/com/firebolt/jdbc/util/VersionUtilTest.java
+++ b/src/test/java/com/firebolt/jdbc/util/VersionUtilTest.java
@@ -1,6 +1,7 @@
 package com.firebolt.jdbc.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -13,12 +14,13 @@ class VersionUtilTest {
 
 	@Test
 	void shouldGetDriverMinorVersion() {
-		assertEquals(5, VersionUtil.getDriverMinorVersion());
+		int minorVersion = VersionUtil.getDriverMinorVersion();
+		assertTrue(minorVersion >= 0 && minorVersion < 100);
 	}
 
 	@Test
 	void shouldGetProjectVersion() {
-		assertEquals("3.5.0", VersionUtil.getDriverVersion());
+		assertTrue(VersionUtil.getDriverVersion().matches("3\\.\\d+\\.\\d+"));
 	}
 
 	@Test


### PR DESCRIPTION
Relaxing minor version check to avoid having to fix tests every time we do a version bump. We still check the methods are callable and return within reason (0 - 100).