### PR TITLE
ci: Auto version bump and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,8 @@ jobs:
   build:
     needs: bump-version
     uses: ./.github/workflows/build.yml
+    with:
+      branch: ${{ github.event.inputs.tag_name }}
 
   publish:
     runs-on: ubuntu-latest
@@ -71,7 +73,7 @@ jobs:
       with:
         file: ${{ needs.build.outputs.uber-jar }}
         tags: true
-        draft: false
+        draft: true
         tag_name: ${{ github.event.inputs.tag_name }}
     # - name: Deploy to Maven Central repository
     #   run: ./gradlew publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,38 @@ on:
         required: true
 
 jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Bump version
+      run: |
+        newVersion=$(echo $newVersion | sed 's/^v//')
+        sed -i.bak "s/^version=.*/version=$newVersion/" gradle.properties
+        rm gradle.properties.bak
+      env:
+        newVersion: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+
+    - name: Setup git config
+      run: |
+        git config user.name "GitHub Actions Bot"
+        git config user.email "<>"
+
+    - name: Commit version bump
+      run: |
+        git add gradle.properties
+        git commit -m "Bump version to $newVersion"
+      env:
+        newVersion: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+
+    - name: Push changes
+      run: git push
+
+
   build:
+    needs: bump-version
     uses: ./.github/workflows/build.yml
 
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release new version
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       tag_name:
@@ -12,6 +10,8 @@ on:
 jobs:
   bump-version:
     runs-on: ubuntu-latest
+    env:
+      newVersion: ${{ github.event.inputs.tag_name }}
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -21,8 +21,6 @@ jobs:
         newVersion=$(echo $newVersion | sed 's/^v//')
         sed -i.bak "s/^version=.*/version=$newVersion/" gradle.properties
         rm gradle.properties.bak
-      env:
-        newVersion: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
 
     - name: Setup git config
       run: |
@@ -32,12 +30,17 @@ jobs:
     - name: Commit version bump
       run: |
         git add gradle.properties
-        git commit -m "Bump version to $newVersion"
-      env:
-        newVersion: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+        git commit -m "chore: Bump version to $newVersion"
+
+    - name: Tag version
+      run: |
+        git tag $newVersion
 
     - name: Push changes
-      run: git push
+      run: |
+        git push origin master
+        # Push tag
+        git push origin $newVersion
 
 
   build:
@@ -51,7 +54,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.release.tag_name || github.event.inputs.tag_name}}
+        ref: ${{ github.event.inputs.tag_name}}
     - name: Download uber-jar
       uses: actions/download-artifact@v4.1.7
       with:
@@ -67,6 +70,7 @@ jobs:
         file: ${{ needs.build.outputs.uber-jar }}
         tags: true
         draft: false
+        tag_name: ${{ github.event.inputs.tag_name }}
     - name: Deploy to Maven Central repository
       run: ./gradlew publish
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v4
-      with:
-        ref: ci-auto-version-bump
 
-    - name: Bump version
+    - name: Bump version in gradle.properties
       run: |
         newVersion=$(echo $newVersion | sed 's/^v//')
         sed -i.bak "s/^version=.*/version=$newVersion/" gradle.properties
@@ -40,7 +38,7 @@ jobs:
 
     - name: Push changes
       run: |
-        git push origin ci-auto-version-bump
+        git push origin master
         # Push tag
         git push origin $newVersion
 
@@ -73,12 +71,12 @@ jobs:
       with:
         file: ${{ needs.build.outputs.uber-jar }}
         tags: true
-        draft: true
+        draft: false
         tag_name: ${{ github.event.inputs.tag_name }}
-    # - name: Deploy to Maven Central repository
-    #   run: ./gradlew publish
-    #   env:
-    #     MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
-    #     MAVEN_REPO_PASSWORD: ${{ secrets.MAVEN_REPO_PASSWORD }}
-    #     GRADLE_SIGNING_KEY: ${{ secrets.GRADLE_SIGNING_KEY }}
-    #     GRADLE_SIGNING_PASSWORD: ${{ secrets.GRADLE_SIGNING_PASSWORD }}
+    - name: Deploy to Maven Central repository
+      run: ./gradlew publish
+      env:
+        MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
+        MAVEN_REPO_PASSWORD: ${{ secrets.MAVEN_REPO_PASSWORD }}
+        GRADLE_SIGNING_KEY: ${{ secrets.GRADLE_SIGNING_KEY }}
+        GRADLE_SIGNING_PASSWORD: ${{ secrets.GRADLE_SIGNING_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v4
+      with:
+        ref: ci-auto-version-bump
 
     - name: Bump version
       run: |
@@ -38,7 +40,7 @@ jobs:
 
     - name: Push changes
       run: |
-        git push origin master
+        git push origin ci-auto-version-bump
         # Push tag
         git push origin $newVersion
 
@@ -71,10 +73,10 @@ jobs:
         tags: true
         draft: false
         tag_name: ${{ github.event.inputs.tag_name }}
-    - name: Deploy to Maven Central repository
-      run: ./gradlew publish
-      env:
-        MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
-        MAVEN_REPO_PASSWORD: ${{ secrets.MAVEN_REPO_PASSWORD }}
-        GRADLE_SIGNING_KEY: ${{ secrets.GRADLE_SIGNING_KEY }}
-        GRADLE_SIGNING_PASSWORD: ${{ secrets.GRADLE_SIGNING_PASSWORD }}
+    # - name: Deploy to Maven Central repository
+    #   run: ./gradlew publish
+    #   env:
+    #     MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
+    #     MAVEN_REPO_PASSWORD: ${{ secrets.MAVEN_REPO_PASSWORD }}
+    #     GRADLE_SIGNING_KEY: ${{ secrets.GRADLE_SIGNING_KEY }}
+    #     GRADLE_SIGNING_PASSWORD: ${{ secrets.GRADLE_SIGNING_PASSWORD }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=3.0.999
+version=3.5.0
 jdbcVersion=4.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.0.1
+version=0.0.2
 jdbcVersion=4.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.0.2
+version=3.0.999
 jdbcVersion=4.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=3.5.0
+version=0.0.1
 jdbcVersion=4.3


### PR DESCRIPTION
Eliminating the need to bump version manually, we only need to provide it on the action run.
Manual Maven release is still needed.

Verified changes during a dummy run (without maven publishing).