### PR TITLE
feat: FIR-43038 allow jdbc to send batch as a single multi statement

### DIFF
--- a/src/integrationTest/java/integration/tests/ConnectionTest.java
+++ b/src/integrationTest/java/integration/tests/ConnectionTest.java
@@ -176,20 +176,42 @@ class ConnectionTest extends IntegrationTest {
     @Tag("v2")
     void preparedStatementBatchesWorkIfMergeParameterProvided() throws SQLException {
         String engineName = integration.ConnectionInfo.getInstance().getEngine();
+        String queryLabel = "test_merge_batches_" + System.currentTimeMillis();
         try (Connection connection = createConnection(engineName, Map.of("merge_prepared_statement_batches", "true"))) {
             try (Statement statement = connection.createStatement()) {
                 statement.executeUpdate("CREATE TABLE test_table (id INT)");
-                try (java.sql.PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO test_table VALUES (?)")) {
+                try (java.sql.PreparedStatement preparedStatement = connection.prepareStatement(
+                        String.format("/*%s*/INSERT INTO test_table VALUES (?)", queryLabel))) {
                     for (int i = 0; i < 10; i++) {
                         preparedStatement.setInt(1, i);
                         preparedStatement.addBatch();
                     }
                     preparedStatement.executeBatch();
+
                 }
                 try (ResultSet rs = statement.executeQuery("SELECT COUNT(*) FROM test_table")) {
                     assertTrue(rs.next());
                     assertEquals(10, rs.getInt(1));
                 }
+                // sleep for 10s to give QH time to get populated and avoid flakiness
+                // it sometime takes that long
+                try {
+                    Thread.sleep(10000);
+                } catch (InterruptedException e) {
+                    // ignore
+                }
+
+                // Validate we've only executed one insert
+                String qhQuery = "SELECT count(*) from information_schema.engine_query_history WHERE status='ENDED_SUCCESSFULLY' " +
+                        String.format("AND lower(query_text) like '/*%s*/insert into %%'", queryLabel);
+                System.out.println(qhQuery);
+                try (java.sql.PreparedStatement preparedStatement = connection.prepareStatement(qhQuery)) {
+                    try (ResultSet rs = preparedStatement.executeQuery()) {
+                        assertTrue(rs.next());
+                        assertEquals(1, rs.getInt(1));
+                    }
+                }
+
             } finally {
                 try (Statement statement = connection.createStatement()) {
                     statement.executeUpdate("DROP TABLE IF EXISTS test_table");

--- a/src/integrationTest/java/integration/tests/PreparedStatementTest.java
+++ b/src/integrationTest/java/integration/tests/PreparedStatementTest.java
@@ -483,7 +483,7 @@ class PreparedStatementTest extends IntegrationTest {
 							.executeQuery("SELECT test_struct FROM test_struct")) {
 				rs.next();
 				assertEquals(FireboltDataType.STRUCT.name().toLowerCase()
-						+ "(id int, s struct(a array(text null), `b column` timestamp null))",
+						+ "(id int, s struct(a array(text null) null, `b column` timestamp null))",
 						rs.getMetaData().getColumnTypeName(1).toLowerCase());
 				String expectedJson = String.format(
 						"{\"id\":%d,\"s\":{\"a\":[\"%s\",\"%s\"],\"b column\":\"%s\"}}", 1, car1.getTags()[0],

--- a/src/integrationTest/java/integration/tests/TimeoutTest.java
+++ b/src/integrationTest/java/integration/tests/TimeoutTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @CustomLog
 class TimeoutTest extends IntegrationTest {
 	private static final int MIN_TIME_SECONDS = 350;
-	private static final Map<Integer, Long> SERIES_SIZE = Map.of(1, 80000000000L, 2, 700000000000L);
+	private static final Map<Integer, Long> SERIES_SIZE = Map.of(1, 80000000000L, 2, 400000000000L);
 	private long startTime;
 
 	@BeforeEach

--- a/src/integrationTest/resources/statements/prepared-statement-struct/ddl.sql
+++ b/src/integrationTest/resources/statements/prepared-statement-struct/ddl.sql
@@ -6,5 +6,5 @@ SET prevent_create_on_information_schema=true;
 SET enable_create_table_with_struct_type=true;
 DROP TABLE IF EXISTS test_struct;
 DROP TABLE IF EXISTS test_struct_helper;
-CREATE TABLE IF NOT EXISTS test_struct(id int not null, s struct(a array(text) not null, "b column" datetime null) not null);
+CREATE TABLE IF NOT EXISTS test_struct(id int not null, s struct(a array(text) null, "b column" datetime null) not null);
 CREATE TABLE IF NOT EXISTS test_struct_helper(a array(text) not null, "b column" datetime null);

--- a/src/main/java/com/firebolt/jdbc/connection/settings/FireboltProperties.java
+++ b/src/main/java/com/firebolt/jdbc/connection/settings/FireboltProperties.java
@@ -76,6 +76,7 @@ public class FireboltProperties {
 	private final String userClients;
 	private final String accessToken;
 	private final boolean validateOnSystemEngine;
+	private final boolean mergeBatches;
 	@Builder.Default
 	private Map<String, String> initialAdditionalProperties = new HashMap<>();
 	@Builder.Default
@@ -112,6 +113,7 @@ public class FireboltProperties {
 		userDrivers = getSetting(properties, FireboltSessionProperty.USER_DRIVERS);
 		userClients = getSetting(properties, FireboltSessionProperty.USER_CLIENTS);
 		validateOnSystemEngine = getSetting(properties, FireboltSessionProperty.VALIDATE_ON_SYSTEM_ENGINE);
+		mergeBatches = getSetting(properties, FireboltSessionProperty.MERGE_BATCHES);
 
 		environment = getEnvironment(configuredEnvironment, properties);
 		host = getHost(configuredEnvironment, properties);

--- a/src/main/java/com/firebolt/jdbc/connection/settings/FireboltProperties.java
+++ b/src/main/java/com/firebolt/jdbc/connection/settings/FireboltProperties.java
@@ -76,7 +76,7 @@ public class FireboltProperties {
 	private final String userClients;
 	private final String accessToken;
 	private final boolean validateOnSystemEngine;
-	private final boolean mergeBatches;
+	private final boolean mergePreparedStatementBatches;
 	@Builder.Default
 	private Map<String, String> initialAdditionalProperties = new HashMap<>();
 	@Builder.Default
@@ -113,7 +113,7 @@ public class FireboltProperties {
 		userDrivers = getSetting(properties, FireboltSessionProperty.USER_DRIVERS);
 		userClients = getSetting(properties, FireboltSessionProperty.USER_CLIENTS);
 		validateOnSystemEngine = getSetting(properties, FireboltSessionProperty.VALIDATE_ON_SYSTEM_ENGINE);
-		mergeBatches = getSetting(properties, FireboltSessionProperty.MERGE_BATCHES);
+		mergePreparedStatementBatches = getSetting(properties, FireboltSessionProperty.MERGE_PREPARED_STATEMENT_BATCHES);
 
 		environment = getEnvironment(configuredEnvironment, properties);
 		host = getHost(configuredEnvironment, properties);

--- a/src/main/java/com/firebolt/jdbc/connection/settings/FireboltSessionProperty.java
+++ b/src/main/java/com/firebolt/jdbc/connection/settings/FireboltSessionProperty.java
@@ -70,8 +70,8 @@ public enum FireboltSessionProperty {
 	VALIDATE_ON_SYSTEM_ENGINE("validate_on_system_engine", false, Boolean.class,
 			"Whether to validate the connection on the system engine or not. By default validates on an engine currently connected.",
 			FireboltProperties::isValidateOnSystemEngine),
-	MERGE_BATCHES("merge_batches", false, Boolean.class,
-			"Whether to send batches as a single statement. By default, batches are sent one by one.", FireboltProperties::isMergeBatches),
+	MERGE_PREPARED_STATEMENT_BATCHES("merge_prepared_statement_batches", false, Boolean.class,
+			"Whether to send prepared statement batches as a single statement. By default, they are sent one by one.", FireboltProperties::isMergePreparedStatementBatches),
 	// We keep all the deprecated properties to ensure backward compatibility - but
 	// they do not have any effect.
 	@Deprecated

--- a/src/main/java/com/firebolt/jdbc/connection/settings/FireboltSessionProperty.java
+++ b/src/main/java/com/firebolt/jdbc/connection/settings/FireboltSessionProperty.java
@@ -70,6 +70,8 @@ public enum FireboltSessionProperty {
 	VALIDATE_ON_SYSTEM_ENGINE("validate_on_system_engine", false, Boolean.class,
 			"Whether to validate the connection on the system engine or not. By default validates on an engine currently connected.",
 			FireboltProperties::isValidateOnSystemEngine),
+	MERGE_BATCHES("merge_batches", false, Boolean.class,
+			"Whether to send batches as a single statement. By default, batches are sent one by one.", FireboltProperties::isMergeBatches),
 	// We keep all the deprecated properties to ensure backward compatibility - but
 	// they do not have any effect.
 	@Deprecated

--- a/src/main/java/com/firebolt/jdbc/statement/FireboltStatement.java
+++ b/src/main/java/com/firebolt/jdbc/statement/FireboltStatement.java
@@ -436,7 +436,7 @@ public class FireboltStatement extends JdbcBase implements Statement {
 				result.add(rs.map(x -> 0).orElse(SUCCESS_NO_INFO));
 			}
 		}
-		return  result.stream().mapToInt(Integer::intValue).toArray();
+		return result.stream().mapToInt(Integer::intValue).toArray();
 	}
 
 	@Override

--- a/src/main/java/com/firebolt/jdbc/statement/FireboltStatement.java
+++ b/src/main/java/com/firebolt/jdbc/statement/FireboltStatement.java
@@ -34,7 +34,7 @@ import static java.util.stream.Collectors.toCollection;
 public class FireboltStatement extends JdbcBase implements Statement {
 
 	private final FireboltStatementService statementService;
-	private final FireboltProperties sessionProperties;
+	protected final FireboltProperties sessionProperties;
 	private final FireboltConnection connection;
 	private final Collection<String> statementsToExecuteLabels = new HashSet<>();
 	private boolean closeOnCompletion = false;

--- a/src/main/java/com/firebolt/jdbc/statement/preparedstatement/FireboltPreparedStatement.java
+++ b/src/main/java/com/firebolt/jdbc/statement/preparedstatement/FireboltPreparedStatement.java
@@ -271,8 +271,8 @@ public class FireboltPreparedStatement extends FireboltStatement implements Prep
 		for (Map<Integer, String> row : rows) {
 			inserts.addAll(prepareSQL(row));
 		}
-		if (sessionProperties.isMergeBatches()) {
-			if (inserts.size() > 0) {
+		if (sessionProperties.isMergePreparedStatementBatches()) {
+			if (!inserts.isEmpty()) {
 				execute(List.of(asSingleStatement(inserts)));
 			}
 		} else {

--- a/src/main/java/com/firebolt/jdbc/statement/preparedstatement/FireboltPreparedStatement.java
+++ b/src/main/java/com/firebolt/jdbc/statement/preparedstatement/FireboltPreparedStatement.java
@@ -266,19 +266,19 @@ public class FireboltPreparedStatement extends FireboltStatement implements Prep
 	public int[] executeBatch() throws SQLException {
 		validateStatementIsNotClosed();
 		log.debug("Executing batch for statement: {}", rawStatement);
-		List<StatementInfoWrapper> inserts = new ArrayList<>();
+		List<StatementInfoWrapper> statements = new ArrayList<>();
 		int[] result = new int[rows.size()];
 		for (Map<Integer, String> row : rows) {
-			inserts.addAll(prepareSQL(row));
+			statements.addAll(prepareSQL(row));
 		}
 		if (sessionProperties.isMergePreparedStatementBatches()) {
-			if (!inserts.isEmpty()) {
-				execute(List.of(asSingleStatement(inserts)));
+			if (!statements.isEmpty()) {
+				execute(List.of(asSingleStatement(statements)));
 			}
 		} else {
-			execute(inserts);
+			execute(statements);
 		}
-		for (int i = 0; i < inserts.size(); i++) {
+		for (int i = 0; i < statements.size(); i++) {
 			result[i] = SUCCESS_NO_INFO;
 		}
 		return result;

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionTest.java
@@ -738,5 +738,16 @@ abstract class FireboltConnectionTest {
 		}
 	}
 
+	@Test
+	void shouldSendBatchesSeparatelyByDefault() throws SQLException {
+		try (FireboltConnection fireboltConnection = createConnection(URL, connectionProperties)) {
+			assertEquals("false", fireboltConnection.getClientInfo().get("merge_batches"));
+		}
+		connectionProperties.put("merge_batches", "true");
+		try (FireboltConnection fireboltConnection = createConnection(URL, connectionProperties)) {
+			assertEquals("true", fireboltConnection.getClientInfo().get("merge_batches"));
+		}
+	}
+
 	protected abstract FireboltConnection createConnection(String url, Properties props) throws SQLException;
 }

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionTest.java
@@ -377,7 +377,7 @@ abstract class FireboltConnectionTest {
 		propertiesCopy.put("merge_prepared_statement_batches", "true");
 		try (FireboltConnection fireboltConnection = createConnection(URL, propertiesCopy)) {
 			fireboltConnection.createStatement().execute("SET param=value");
-			PreparedStatement statement = fireboltConnection.prepareStatement("SELECT ?");
+			PreparedStatement statement = fireboltConnection.prepareStatement("INSERT INTO t VALUES (?)");
 			statement.setInt(1, 1);
 			statement.addBatch();
 			statement.setInt(1, 2);
@@ -385,7 +385,7 @@ abstract class FireboltConnectionTest {
 			statement.executeBatch();
 			verify(fireboltStatementService, atLeast(2)).execute(queryInfoWrapperArgumentCaptor.capture(),
 					propertiesArgumentCaptor.capture(), any());
-			assertEquals("SELECT 1;SELECT 2;", queryInfoWrapperArgumentCaptor.getValue().getSql());
+			assertEquals("INSERT INTO t VALUES (1);INSERT INTO t VALUES (2);", queryInfoWrapperArgumentCaptor.getValue().getSql());
 			// Validate that parameters are preserved
 			assertEquals(Map.of("param", "value"), propertiesArgumentCaptor.getValue().getAdditionalProperties());
 		}

--- a/src/test/java/com/firebolt/jdbc/connection/settings/FireboltPropertiesTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/settings/FireboltPropertiesTest.java
@@ -49,6 +49,7 @@ class FireboltPropertiesTest {
 		properties.put("someCustomProperties", "custom_value");
 		properties.put("compress", "1");
 		properties.put("validate_on_system_engine", "true");
+		properties.put("merge_batches", "true");
 
 		Map<String, String> customProperties = new HashMap<>();
 		customProperties.put("someCustomProperties", "custom_value");
@@ -59,7 +60,7 @@ class FireboltPropertiesTest {
 				.initialAdditionalProperties(customProperties).keepAliveTimeoutMillis(300000)
 				.maxConnectionsTotal(300).maxRetries(3).socketTimeoutMillis(20).connectionTimeoutMillis(60000)
 				.tcpKeepInterval(30).tcpKeepIdle(60).tcpKeepCount(10).environment("app").validateOnSystemEngine(true)
-				.build();
+				.mergeBatches(true).build();
 		assertEquals(expectedDefaultProperties, new FireboltProperties(properties));
 	}
 

--- a/src/test/java/com/firebolt/jdbc/connection/settings/FireboltPropertiesTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/settings/FireboltPropertiesTest.java
@@ -49,7 +49,7 @@ class FireboltPropertiesTest {
 		properties.put("someCustomProperties", "custom_value");
 		properties.put("compress", "1");
 		properties.put("validate_on_system_engine", "true");
-		properties.put("merge_batches", "true");
+		properties.put("merge_prepared_statement_batches", "true");
 
 		Map<String, String> customProperties = new HashMap<>();
 		customProperties.put("someCustomProperties", "custom_value");
@@ -60,7 +60,7 @@ class FireboltPropertiesTest {
 				.initialAdditionalProperties(customProperties).keepAliveTimeoutMillis(300000)
 				.maxConnectionsTotal(300).maxRetries(3).socketTimeoutMillis(20).connectionTimeoutMillis(60000)
 				.tcpKeepInterval(30).tcpKeepIdle(60).tcpKeepCount(10).environment("app").validateOnSystemEngine(true)
-				.mergeBatches(true).build();
+				.mergePreparedStatementBatches(true).build();
 		assertEquals(expectedDefaultProperties, new FireboltProperties(properties));
 	}
 


### PR DESCRIPTION
Added `merge_prepared_statement_batches` parameter to JDBC. If will send all queries in a prepared statement batch as a single http request, separated by semicolon.