### PR TITLE
ci: Add PAT to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.RELEASE_PAT }}
 
     - name: Bump version in gradle.properties
       run: |


### PR DESCRIPTION
This fixes permissions issue when release action attempts to commit to the repo. 