### PR TITLE
feat(FIR-34063):implement get catalogs to return all dbs

### DIFF
--- a/src/integrationTest/java/integration/tests/SystemEngineDatabaseMetaDataTest.java
+++ b/src/integrationTest/java/integration/tests/SystemEngineDatabaseMetaDataTest.java
@@ -9,11 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -59,8 +55,13 @@ public class SystemEngineDatabaseMetaDataTest extends IntegrationTest {
     @Test
     @Tag("v2")
     void getCatalogs() throws SQLException {
-        String database = integration.ConnectionInfo.getInstance().getDatabase();
-        assertTrue(getRows(DatabaseMetaData::getCatalogs).contains(List.of(database)));
+        try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE DATABASE test_get_catalogs");
+            String database = integration.ConnectionInfo.getInstance().getDatabase();
+            assertTrue(getRows(DatabaseMetaData::getCatalogs).contains(List.of(database)));
+            assertTrue(getRows(DatabaseMetaData::getCatalogs).contains(List.of("test_get_catalogs")));
+            statement.executeUpdate("DROP DATABASE test_get_catalogs");
+        }
     }
 
     @ParameterizedTest

--- a/src/integrationTest/java/integration/tests/SystemEngineDatabaseMetaDataTest.java
+++ b/src/integrationTest/java/integration/tests/SystemEngineDatabaseMetaDataTest.java
@@ -26,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SystemEngineDatabaseMetaDataTest extends IntegrationTest {
     private static final long ID = ProcessHandle.current().pid() + System.currentTimeMillis();
-    private static final String DATABASE_NAME = "jdbc_system_engine_integration_test_" + ID;
     private Connection connection;
     private DatabaseMetaData dbmd;
 
@@ -58,13 +57,13 @@ public class SystemEngineDatabaseMetaDataTest extends IntegrationTest {
 	@Tag("v2")
 	void getCatalogs() throws SQLException {
 		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
-			try {
-				statement.executeUpdate(format("CREATE DATABASE %s", DATABASE_NAME));
-				String database = integration.ConnectionInfo.getInstance().getDatabase();
+            String database = integration.ConnectionInfo.getInstance().getDatabase();
+            try {
+				statement.executeUpdate(format("CREATE DATABASE %s_get_catalogs", database));
 				assertTrue(getRows(DatabaseMetaData::getCatalogs).contains(List.of(database)));
-				assertTrue(getRows(DatabaseMetaData::getCatalogs).contains(List.of(DATABASE_NAME)));
+				assertTrue(getRows(DatabaseMetaData::getCatalogs).contains(List.of(database)));
 			} finally {
-				statement.executeUpdate(format("DROP DATABASE IF EXISTS %s", DATABASE_NAME));
+				statement.executeUpdate(format("DROP DATABASE IF EXISTS %s_get_catalogs", database));
 			}
 		}
     }

--- a/src/integrationTest/java/integration/tests/SystemEngineDatabaseMetaDataTest.java
+++ b/src/integrationTest/java/integration/tests/SystemEngineDatabaseMetaDataTest.java
@@ -25,6 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SystemEngineDatabaseMetaDataTest extends IntegrationTest {
+    private static final long ID = ProcessHandle.current().pid() + System.currentTimeMillis();
+    private static final String DATABASE_NAME = "jdbc_system_engine_integration_test_" + ID;
     private Connection connection;
     private DatabaseMetaData dbmd;
 
@@ -52,16 +54,19 @@ public class SystemEngineDatabaseMetaDataTest extends IntegrationTest {
         assertEquals(List.of(List.of("information_schema", database)), getRows(DatabaseMetaData::getSchemas));
     }
 
-    @Test
-    @Tag("v2")
-    void getCatalogs() throws SQLException {
-        try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
-            statement.executeUpdate("CREATE DATABASE test_get_catalogs");
-            String database = integration.ConnectionInfo.getInstance().getDatabase();
-            assertTrue(getRows(DatabaseMetaData::getCatalogs).contains(List.of(database)));
-            assertTrue(getRows(DatabaseMetaData::getCatalogs).contains(List.of("test_get_catalogs")));
-            statement.executeUpdate("DROP DATABASE test_get_catalogs");
-        }
+	@Test
+	@Tag("v2")
+	void getCatalogs() throws SQLException {
+		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
+			try {
+				statement.executeUpdate(format("CREATE DATABASE %s", DATABASE_NAME));
+				String database = integration.ConnectionInfo.getInstance().getDatabase();
+				assertTrue(getRows(DatabaseMetaData::getCatalogs).contains(List.of(database)));
+				assertTrue(getRows(DatabaseMetaData::getCatalogs).contains(List.of(DATABASE_NAME)));
+			} finally {
+				statement.executeUpdate(format("DROP DATABASE IF EXISTS %s", DATABASE_NAME));
+			}
+		}
     }
 
     @ParameterizedTest

--- a/src/integrationTest/java/integration/tests/SystemEngineDatabaseMetaDataTest.java
+++ b/src/integrationTest/java/integration/tests/SystemEngineDatabaseMetaDataTest.java
@@ -53,7 +53,14 @@ public class SystemEngineDatabaseMetaDataTest extends IntegrationTest {
     @Tag("v2")
     void getSchemas() throws SQLException {
         String database = integration.ConnectionInfo.getInstance().getDatabase();
-        assertEquals(List.of(List.of("information_schema", database)), getSchemas(DatabaseMetaData::getSchemas));
+        assertEquals(List.of(List.of("information_schema", database)), getRows(DatabaseMetaData::getSchemas));
+    }
+
+    @Test
+    @Tag("v2")
+    void getCatalogs() throws SQLException {
+        String database = integration.ConnectionInfo.getInstance().getDatabase();
+        assertTrue(getRows(DatabaseMetaData::getCatalogs).contains(List.of(database)));
     }
 
     @ParameterizedTest
@@ -80,7 +87,7 @@ public class SystemEngineDatabaseMetaDataTest extends IntegrationTest {
                 List.of()
                 :
                 Arrays.stream(expectedSchemasStr.split(";")).map(schema -> List.of(schema, database)).collect(toList());
-        assertEquals(expectedSchemas, getSchemas(dbmd -> dbmd.getSchemas(cat, schemaPattern)));
+        assertEquals(expectedSchemas, getRows(dbmd -> dbmd.getSchemas(cat, schemaPattern)));
     }
 
     @ParameterizedTest
@@ -211,7 +218,7 @@ public class SystemEngineDatabaseMetaDataTest extends IntegrationTest {
         }
     }
 
-    private List<List<Object>> getSchemas(CheckedFunction<DatabaseMetaData, ResultSet> schemasGetter) throws SQLException {
+    private List<List<Object>> getRows(CheckedFunction<DatabaseMetaData, ResultSet> schemasGetter) throws SQLException {
         return readResultSet(schemasGetter.apply(dbmd));
     }
 

--- a/src/main/java/com/firebolt/jdbc/metadata/FireboltDatabaseMetadata.java
+++ b/src/main/java/com/firebolt/jdbc/metadata/FireboltDatabaseMetadata.java
@@ -201,7 +201,15 @@ public class FireboltDatabaseMetadata implements DatabaseMetaData, GenericWrappe
 
 	@Override
 	public ResultSet getCatalogs() throws SQLException {
-		return createResultSet(Stream.of(entry(TABLE_CAT, TEXT)), List.of(List.of(connection.getCatalog())));
+		List<List<?>> rows = new ArrayList<>();
+		String query = "SELECT CATALOG_NAME AS TABLE_CAT FROM information_schema.catalogs ORDER BY TABLE_CAT";
+		try (Statement statement = connection.createStatement();
+			 ResultSet catalogNames = statement.executeQuery(query)) {
+			while (catalogNames.next()) {
+				rows.add(List.of(catalogNames.getString(TABLE_CAT)));
+			}
+		}
+		return createResultSet(Stream.of(entry(TABLE_CAT, TEXT)), rows);
 	}
 
 	@Override

--- a/src/test/java/com/firebolt/jdbc/metadata/FireboltDatabaseMetadataTest.java
+++ b/src/test/java/com/firebolt/jdbc/metadata/FireboltDatabaseMetadataTest.java
@@ -126,7 +126,9 @@ class FireboltDatabaseMetadataTest {
 	void shouldReturnCatalogs() throws SQLException {
 		ResultSet expectedResultSet = FireboltResultSet.of(QueryResult.builder()
 				.columns(Collections.singletonList(Column.builder().name(TABLE_CAT).type(TEXT).build()))
-				.rows(Collections.singletonList(Collections.singletonList("db_name"))).build());
+				.rows(Arrays.asList(Collections.singletonList("db_name1"), Collections.singletonList("db_name2"))).build());
+
+		when(statement.executeQuery(anyString())).thenReturn(createResultSet(getInputStreamForGetCatalogs()));
 
 		ResultSet actualResultSet = fireboltDatabaseMetadata.getCatalogs();
 
@@ -893,6 +895,10 @@ class FireboltDatabaseMetadataTest {
 
 	private InputStream getInputStreamForGetVersion() {
 		return FireboltDatabaseMetadata.class.getResourceAsStream("/responses/metadata/firebolt-response-get-version-example");
+	}
+
+	private InputStream getInputStreamForGetCatalogs() {
+		return FireboltDatabaseMetadata.class.getResourceAsStream("/responses/metadata/firebolt-response-get-catalogs-example");
 	}
 
 	private InputStream getExpectedTypeInfo() {

--- a/src/test/resources/responses/metadata/firebolt-response-get-catalogs-example
+++ b/src/test/resources/responses/metadata/firebolt-response-get-catalogs-example
@@ -1,0 +1,4 @@
+table_cat
+String
+db_name1
+db_name2


### PR DESCRIPTION
Implemented the getCatalogs method from FireboltDatabaseMetadata to return all catalogs instead of just the one from the connection. Changed the existing unit test for this method and also created an integration test that checks that at least the current db provided for the integration tests is returned in the ResultSet (due to there being lots of databases available in staging)