### PR TITLE
feat: FIR-43922 - part2 - remove duplicate line

### DIFF
--- a/src/main/java/com/firebolt/jdbc/client/query/StatementClientImpl.java
+++ b/src/main/java/com/firebolt/jdbc/client/query/StatementClientImpl.java
@@ -136,7 +136,6 @@ public class StatementClientImpl extends FireboltClient implements StatementClie
 	@Override
 	public InputStream executeSqlStatement(@NonNull StatementInfoWrapper statementInfoWrapper,
 										   @NonNull FireboltProperties connectionProperties, boolean systemEngine, int queryTimeout) throws SQLException {
-		QueryIdFetcher.getQueryFetcher(connection.getInfraVersion()).formatStatement(statementInfoWrapper);
 		String formattedStatement = QueryIdFetcher.getQueryFetcher(connection.getInfraVersion()).formatStatement(statementInfoWrapper);
 		Map<String, String> params = getAllParameters(connectionProperties, statementInfoWrapper, systemEngine, queryTimeout);
 		String label = statementInfoWrapper.getLabel();

--- a/src/test/java/com/firebolt/jdbc/client/query/StatementClientImplTest.java
+++ b/src/test/java/com/firebolt/jdbc/client/query/StatementClientImplTest.java
@@ -102,7 +102,6 @@ class StatementClientImplTest {
 		expectedHeaders.put("Authorization", "Bearer token");
 		expectedHeaders.put("User-Agent", userAgent("ConnB/2.0.9 JDBC/%s (Java %s; %s %s; ) ConnA/1.0.9"));
 		assertEquals(expectedHeaders, extractHeadersMap(actualRequest));
-		//assertEquals("show databases;", actualQuery);
 		assertSqlStatement("show databases;", actualQuery);
 		return Map.entry(statementInfoWrapper.getLabel(), actualRequest.url().toString());
 	}


### PR DESCRIPTION
This line was executed twice: 
QueryIdFetcher.getQueryFetcher(connection.getInfraVersion()).formatStatement(statementInfoWrapper);

One by itself and one to have the result assigned to a variable. Only keep one call. 

Also removed a commented line from tests. 