### PR TITLE
feat: FIR-44116 Line and Column information missing from JDBC errors

### DIFF
--- a/src/integrationTest/java/integration/tests/StatementTest.java
+++ b/src/integrationTest/java/integration/tests/StatementTest.java
@@ -117,6 +117,8 @@ class StatementTest extends IntegrationTest {
 		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
 			String errorMessage = assertThrows(FireboltException.class, () -> statement.executeQuery("select wrong query")).getMessage();
 			assertTrue(errorMessage.contains("wrong"));
+			assertTrue(errorMessage.contains("Line 1"));
+			assertTrue(errorMessage.contains("Column 8"));
 		}
 	}
 
@@ -129,6 +131,8 @@ class StatementTest extends IntegrationTest {
 			statement.execute("set enable_json_error_output_format=true");
 			String errorMessage = assertThrows(FireboltException.class, () -> statement.executeQuery("select wrong query")).getMessage();
 			assertTrue(errorMessage.contains("Column 'wrong' does not exist."));
+			assertTrue(errorMessage.contains("Line 1"));
+			assertTrue(errorMessage.contains("Column 8"));
 		}
 	}
 

--- a/src/main/java/com/firebolt/jdbc/exception/ServerError.java
+++ b/src/main/java/com/firebolt/jdbc/exception/ServerError.java
@@ -127,10 +127,13 @@ public class ServerError {
         }
 
         Error(JSONObject json) {
-            this(json.optString("code", null), json.optString("name", null),
+            this(json.optString("code", null),
+                    json.optString("name", null),
                     json.optEnum(Severity.class, "severity"),
                     ofNullable(json.optString("source", null)).map(Source::fromText).orElse(Source.UNKNOWN),
-                    json.optString("description", null), json.optString("resolution", null), json.optString("helpLink", null),
+                    json.optString("description", null),
+                    json.optString("resolution", null),
+                    json.optString("helpLink", null),
                     ofNullable(json.optJSONObject("location", null)).map(Location::new).orElse(null));
         }
 
@@ -190,7 +193,7 @@ public class ServerError {
             }
 
             Location(JSONObject json) {
-                this(json.optInt("failingLine"), json.optInt("startOffset"), json.optInt("endOffset"));
+                this(json.optInt("failing_line"), json.optInt("start_offset"), json.optInt("end_offset"));
             }
 
             @Override

--- a/src/test/java/com/firebolt/jdbc/exception/ServerErrorTest.java
+++ b/src/test/java/com/firebolt/jdbc/exception/ServerErrorTest.java
@@ -21,7 +21,7 @@ class ServerErrorTest {
                 Arguments.of("{\"query\": {}, \"errors\": []}", new ServerError(new Query(null, null, null), new Error[0])),
                 Arguments.of("{\"query\": {\"query_id\": \"qid\", \"request_id\": \"rid\", \"query_label\": \"ql\"}, \"errors\": []}", new ServerError(new Query("qid", "rid", "ql"), new Error[0])),
                 Arguments.of("{\"errors\": [{}]}", new ServerError(null, new Error[] {new Error(null, null, null, Source.UNKNOWN, null, null, null, null)})),
-                Arguments.of("{\"errors\": [{\"code\": \"c1\", \"name\": \"name1\", \"severity\": \"ERROR\", \"source\": \"System Error\", \"description\": \"description1\", \"resolution\": \"resolution1\", \"helpLink\": \"http://help1.com\", \"location\": {\"failingLine\": 1, \"startOffset\": 10, \"endOffset\": 100}}]}",
+                Arguments.of("{\"errors\": [{\"code\": \"c1\", \"name\": \"name1\", \"severity\": \"ERROR\", \"source\": \"System Error\", \"description\": \"description1\", \"resolution\": \"resolution1\", \"helpLink\": \"http://help1.com\", \"location\": {\"failing_line\": 1, \"start_offset\": 10, \"end_offset\": 100}}]}",
                         new ServerError(null, new Error[] {new Error("c1", "name1", Severity.ERROR, Source.SYSTEM_ERROR, "description1", "resolution1", "http://help1.com", new Location(1, 10, 100))}))
         );
     }


### PR DESCRIPTION
Updated ServerError creation to not trim the error message anymore, but to leave it complete. Now the error message is 1:1 with the one received from the server, so no more missing the line/column information