### PR TITLE
feat: FIR-38161 Fix unauthorized error message fetching in ServerError

### DIFF
--- a/src/integrationTest/java/integration/IntegrationTest.java
+++ b/src/integrationTest/java/integration/IntegrationTest.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 import lombok.CustomLog;
 import lombok.SneakyThrows;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInstance;
 
@@ -53,12 +54,16 @@ public abstract class IntegrationTest {
 	}
 
 	protected Connection createConnection(String engine, String database) throws SQLException {
-		ConnectionInfo current = integration.ConnectionInfo.getInstance();
-		ConnectionInfo updated = new ConnectionInfo(current.getPrincipal(), current.getSecret(),
-				current.getEnv(), database, current.getAccount(), engine, current.getApi(), Collections.emptyMap());
+		ConnectionInfo updated = getConnectionInfoWithEngineAndDatabase(engine, database);
 		return DriverManager.getConnection(updated.toJdbcUrl(),
 				integration.ConnectionInfo.getInstance().getPrincipal(),
 				integration.ConnectionInfo.getInstance().getSecret());
+	}
+
+	protected ConnectionInfo getConnectionInfoWithEngineAndDatabase(String engine, String database) {
+		ConnectionInfo current = ConnectionInfo.getInstance();
+        return new ConnectionInfo(current.getPrincipal(), current.getSecret(),
+                current.getEnv(), database, current.getAccount(), engine, current.getApi(), Collections.emptyMap());
 	}
 
 	protected Connection createConnection(String engine, Map<String, String> extra) throws SQLException {

--- a/src/integrationTest/java/integration/tests/ConnectionTest.java
+++ b/src/integrationTest/java/integration/tests/ConnectionTest.java
@@ -243,7 +243,7 @@ class ConnectionTest extends IntegrationTest {
 
     @Test
     @Tag("v2")
-    void networkPolicyBlockedServiceAccountThrowsErrorWhenFetchingEngineUrl() throws SQLException {
+    void networkPolicyBlockedServiceAccountThrowsError() throws SQLException {
         try (Connection connection = createConnection();
              Statement statement = connection.createStatement()) {
             //this is done as to not clutter the environment variables for one test

--- a/src/integrationTest/java/integration/tests/StatementTest.java
+++ b/src/integrationTest/java/integration/tests/StatementTest.java
@@ -5,19 +5,6 @@ import com.firebolt.jdbc.exception.FireboltException;
 import integration.ConnectionInfo;
 import integration.EnvironmentCondition;
 import integration.IntegrationTest;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
 import kotlin.collections.ArrayDeque;
 import lombok.CustomLog;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -31,6 +18,21 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static integration.EnvironmentCondition.Attribute.fireboltVersion;
 import static java.lang.String.format;
 import static java.sql.Statement.SUCCESS_NO_INFO;
 import static java.util.stream.Collectors.joining;
@@ -127,7 +129,7 @@ class StatementTest extends IntegrationTest {
 
 	@Test
 	@Tag("v2")
-	@EnvironmentCondition(value = "4.2.0", comparison = EnvironmentCondition.Comparison.GE)
+	@EnvironmentCondition(value = "4.2.0", attribute = fireboltVersion, comparison = EnvironmentCondition.Comparison.GE)
 	void shouldThrowExceptionWhenExecutingWrongQueryWithJsonError() throws SQLException {
 		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
 			statement.execute("set advanced_mode=1");
@@ -316,7 +318,7 @@ class StatementTest extends IntegrationTest {
 				String statementWithoutExplicitQueryLabel = "SELECT " + RandomStringUtils.randomNumeric(3)  + ";";
 				statement.executeQuery(statementWithoutExplicitQueryLabel);
 
-				// sleep for some time to allow query history to execute 
+				// sleep for some time to allow query history to execute
 				sleepForMillis(TEN_SECONDS_IN_MILLIS);
 
 				String implicitQueryLabel = getQueryLabel(statement, currentTime, statementWithoutExplicitQueryLabel);

--- a/src/integrationTest/java/integration/tests/StatementTest.java
+++ b/src/integrationTest/java/integration/tests/StatementTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
+import static integration.EnvironmentCondition.Attribute.databaseVersion;
 import static integration.EnvironmentCondition.Attribute.fireboltVersion;
 import static java.lang.String.format;
 import static java.sql.Statement.SUCCESS_NO_INFO;
@@ -129,7 +130,7 @@ class StatementTest extends IntegrationTest {
 
 	@Test
 	@Tag("v2")
-	@EnvironmentCondition(value = "4.2.0", attribute = fireboltVersion, comparison = EnvironmentCondition.Comparison.GE)
+	@EnvironmentCondition(value = "4.2.0", attribute = databaseVersion, comparison = EnvironmentCondition.Comparison.GE)
 	void shouldThrowExceptionWhenExecutingWrongQueryWithJsonError() throws SQLException {
 		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
 			statement.execute("set advanced_mode=1");

--- a/src/integrationTest/java/integration/tests/SystemEngineTest.java
+++ b/src/integrationTest/java/integration/tests/SystemEngineTest.java
@@ -1,6 +1,7 @@
 package integration.tests;
 
 import static com.firebolt.jdbc.connection.FireboltConnectionUserPassword.SYSTEM_ENGINE_NAME;
+import static integration.EnvironmentCondition.Attribute.databaseVersion;
 import static integration.EnvironmentCondition.Attribute.fireboltVersion;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -88,7 +89,7 @@ public class SystemEngineTest extends IntegrationTest {
 	}
 
 	@Test
-	@EnvironmentCondition(value = "4.2.0", attribute = fireboltVersion, comparison = EnvironmentCondition.Comparison.GE)
+	@EnvironmentCondition(value = "4.2.0", attribute = databaseVersion, comparison = EnvironmentCondition.Comparison.GE)
 	void shouldThrowExceptionWhenExecutingWrongQueryWithJsonError() throws SQLException {
 		try (Connection connection = createConnection(getSystemEngineName()); Statement statement = connection.createStatement()) {
 			statement.execute("set advanced_mode=1");

--- a/src/main/java/com/firebolt/jdbc/exception/ServerError.java
+++ b/src/main/java/com/firebolt/jdbc/exception/ServerError.java
@@ -37,14 +37,14 @@ public class ServerError {
         }
     }
 
-	private static Error[] fromJson(JSONArray jsonArray) {
-		return jsonArray == null
+    private static Error[] fromJson(JSONArray jsonArray) {
+        return jsonArray == null
                 ? null
-				: IntStream.range(0, jsonArray.length()).boxed()
+                : IntStream.range(0, jsonArray.length()).boxed()
                         .map(jsonArray::getJSONObject)
                         .map(Error::new)
-						.toArray(Error[]::new);
-	}
+                        .toArray(Error[]::new);
+    }
 
     private static <T> T fromJson(JSONObject json, Function<JSONObject, T> factory) {
         return ofNullable(json).map(factory).orElse(null);
@@ -140,7 +140,7 @@ public class ServerError {
             this(json.optString("code", null),
                     json.optString("name", null),
                     json.optEnum(Severity.class, "severity"),
-                    ofNullable(json.optString("source", null)).map(Source::fromText).orElse(Source.UNKNOWN),
+                    ofNullable(json.optString("source", null)).map(Source::fromText).orElse(null),
                     json.optString("description", json.optString("detail", null)),
                     json.optString("resolution", null),
                     json.optString("helpLink", null),

--- a/src/test/java/com/firebolt/jdbc/exception/ServerErrorTest.java
+++ b/src/test/java/com/firebolt/jdbc/exception/ServerErrorTest.java
@@ -17,12 +17,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class ServerErrorTest {
     protected static Stream<Arguments> parse() {
         return Stream.of(
-                Arguments.of("{}", new ServerError(null, null)),
+                Arguments.of("{}", new ServerError(null, new Error[]{new Error(null, null, null, Source.UNKNOWN, null, null, null, null)})),
                 Arguments.of("{\"query\": {}, \"errors\": []}", new ServerError(new Query(null, null, null), new Error[0])),
                 Arguments.of("{\"query\": {\"query_id\": \"qid\", \"request_id\": \"rid\", \"query_label\": \"ql\"}, \"errors\": []}", new ServerError(new Query("qid", "rid", "ql"), new Error[0])),
                 Arguments.of("{\"errors\": [{}]}", new ServerError(null, new Error[] {new Error(null, null, null, Source.UNKNOWN, null, null, null, null)})),
                 Arguments.of("{\"errors\": [{\"code\": \"c1\", \"name\": \"name1\", \"severity\": \"ERROR\", \"source\": \"System Error\", \"description\": \"description1\", \"resolution\": \"resolution1\", \"helpLink\": \"http://help1.com\", \"location\": {\"failing_line\": 1, \"start_offset\": 10, \"end_offset\": 100}}]}",
-                        new ServerError(null, new Error[] {new Error("c1", "name1", Severity.ERROR, Source.SYSTEM_ERROR, "description1", "resolution1", "http://help1.com", new Location(1, 10, 100))}))
+                        new ServerError(null, new Error[] {new Error("c1", "name1", Severity.ERROR, Source.SYSTEM_ERROR, "description1", "resolution1", "http://help1.com", new Location(1, 10, 100))})),
+                Arguments.of("{\"detail\": \"Request denied due to insufficient permissions or network restrictions.\"}",
+                        new ServerError(null, new Error[] {new Error(null, null, null, Source.UNKNOWN, "Request denied due to insufficient permissions or network restrictions.", null, null, null)}))
         );
     }
 

--- a/src/test/java/com/firebolt/jdbc/exception/ServerErrorTest.java
+++ b/src/test/java/com/firebolt/jdbc/exception/ServerErrorTest.java
@@ -17,14 +17,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class ServerErrorTest {
     protected static Stream<Arguments> parse() {
         return Stream.of(
-                Arguments.of("{}", new ServerError(null, new Error[]{new Error(null, null, null, Source.UNKNOWN, null, null, null, null)})),
+                Arguments.of("{}", new ServerError(null, new Error[]{new Error(null, null, null, null, null, null, null, null)})),
                 Arguments.of("{\"query\": {}, \"errors\": []}", new ServerError(new Query(null, null, null), new Error[0])),
                 Arguments.of("{\"query\": {\"query_id\": \"qid\", \"request_id\": \"rid\", \"query_label\": \"ql\"}, \"errors\": []}", new ServerError(new Query("qid", "rid", "ql"), new Error[0])),
-                Arguments.of("{\"errors\": [{}]}", new ServerError(null, new Error[] {new Error(null, null, null, Source.UNKNOWN, null, null, null, null)})),
+                Arguments.of("{\"errors\": [{}]}", new ServerError(null, new Error[] {new Error(null, null, null, null, null, null, null, null)})),
                 Arguments.of("{\"errors\": [{\"code\": \"c1\", \"name\": \"name1\", \"severity\": \"ERROR\", \"source\": \"System Error\", \"description\": \"description1\", \"resolution\": \"resolution1\", \"helpLink\": \"http://help1.com\", \"location\": {\"failing_line\": 1, \"start_offset\": 10, \"end_offset\": 100}}]}",
                         new ServerError(null, new Error[] {new Error("c1", "name1", Severity.ERROR, Source.SYSTEM_ERROR, "description1", "resolution1", "http://help1.com", new Location(1, 10, 100))})),
                 Arguments.of("{\"detail\": \"Request denied due to insufficient permissions or network restrictions.\"}",
-                        new ServerError(null, new Error[] {new Error(null, null, null, Source.UNKNOWN, "Request denied due to insufficient permissions or network restrictions.", null, null, null)}))
+                        new ServerError(null, new Error[] {new Error(null, null, null, null, "Request denied due to insufficient permissions or network restrictions.", null, null, null)}))
         );
     }
 


### PR DESCRIPTION
When a statement is executed from a client which is blocked / not allowed via network policy, the error message from the exception is null, due to the message being found via another key ("detail")