### PR TITLE
feat: FIR-44260 - do not validate connection when changing the paramters set from the server

### DIFF
--- a/src/integrationTest/java/integration/IntegrationTest.java
+++ b/src/integrationTest/java/integration/IntegrationTest.java
@@ -1,11 +1,6 @@
 package integration;
 
 import com.firebolt.jdbc.client.HttpClientConfig;
-import lombok.CustomLog;
-import lombok.SneakyThrows;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestInstance;
-
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
@@ -13,8 +8,15 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.CustomLog;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInstance;
 
 import static com.firebolt.jdbc.connection.FireboltConnectionUserPassword.SYSTEM_ENGINE_NAME;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -25,6 +27,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public abstract class IntegrationTest {
 
 	private static final String JDBC_URL_PREFIX = "jdbc:firebolt:";
+
+	// timestamp format on the backend
+	private static ZoneId UTC_ZONE_ID = ZoneId.of("UTC"); // Change this to your desired timezone
+
+	// Get the current time in the specified timezone
+	private static final String TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss";
+	private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(TIMESTAMP_FORMAT);
 
 	protected Connection createLocalConnection(String queryParams) throws SQLException {
 		return DriverManager.getConnection(
@@ -84,4 +93,20 @@ public abstract class IntegrationTest {
 	protected String getSystemEngineName() {
 		return System.getProperty("api") == null ? null : SYSTEM_ENGINE_NAME;
 	}
+
+	/**
+	 * Assume the back end and the client have the same timestamp
+	 */
+	protected String getCurrentUTCTime() {
+		return ZonedDateTime.now(UTC_ZONE_ID).format(DATE_TIME_FORMATTER);
+	}
+
+	protected void sleepForMillis(long millis) {
+		try {
+			Thread.sleep(millis);
+		} catch (InterruptedException e) {
+			// do nothing
+		}
+	}
+
 }

--- a/src/integrationTest/java/integration/tests/ConnectionTest.java
+++ b/src/integrationTest/java/integration/tests/ConnectionTest.java
@@ -175,7 +175,7 @@ class ConnectionTest extends IntegrationTest {
             selectQueriesRS = statement.executeQuery(String.format(queryHistoryQueryFormat, currentUTCTime));
             assertTrue(selectQueriesRS.next());
 
-            assertEquals("SELECT 222;", selectQueriesRS.getObject(1));
+            assertEquals("SELECT 222;", selectQueriesRS.getString(1));
 
             // no more select statements
             assertFalse(selectQueriesRS.next());

--- a/src/main/java/com/firebolt/jdbc/client/query/StatementClientImpl.java
+++ b/src/main/java/com/firebolt/jdbc/client/query/StatementClientImpl.java
@@ -40,6 +40,8 @@ import okhttp3.internal.http2.StreamResetException;
 @CustomLog
 public class StatementClientImpl extends FireboltClient implements StatementClient {
 
+	private static final boolean DO_NOT_VALIDATE_CONNECTION = false;
+
 	private static final String TAB_SEPARATED_WITH_NAMES_AND_TYPES_FORMAT = "TabSeparatedWithNamesAndTypes";
 	private static final Map<Pattern, String> missConfigurationErrorMessages = Map.of(
 			Pattern.compile("HTTP status code: 401"), "Please associate user with your service account.",
@@ -348,7 +350,7 @@ public class StatementClientImpl extends FireboltClient implements StatementClie
 			}
 			for (String header : response.headers(HEADER_UPDATE_PARAMETER)) {
 				String[] keyValue = header.split("=");
-				connection.addProperty(keyValue[0].trim(), keyValue[1].trim());
+				connection.addProperty(keyValue[0].trim(), keyValue[1].trim(), DO_NOT_VALIDATE_CONNECTION);
 			}
 		}
 	}

--- a/src/main/java/com/firebolt/jdbc/client/query/StatementClientImpl.java
+++ b/src/main/java/com/firebolt/jdbc/client/query/StatementClientImpl.java
@@ -1,25 +1,5 @@
 package com.firebolt.jdbc.client.query;
 
-import static com.firebolt.jdbc.connection.settings.FireboltQueryParameterKey.*;
-import static com.firebolt.jdbc.exception.ExceptionType.INVALID_REQUEST;
-import static com.firebolt.jdbc.exception.ExceptionType.UNAUTHORIZED;
-import static java.lang.String.format;
-import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
-import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
-import static java.util.Optional.ofNullable;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.function.BiPredicate;
-import java.util.function.Function;
-import java.util.regex.Pattern;
-
 import com.firebolt.jdbc.client.FireboltClient;
 import com.firebolt.jdbc.connection.FireboltConnection;
 import com.firebolt.jdbc.connection.settings.FireboltProperties;
@@ -31,16 +11,48 @@ import com.firebolt.jdbc.statement.StatementType;
 import com.firebolt.jdbc.statement.rawstatement.RawStatement;
 import com.firebolt.jdbc.util.CloseableUtil;
 import com.firebolt.jdbc.util.PropertyUtil;
-
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.regex.Pattern;
 import lombok.CustomLog;
 import lombok.NonNull;
-import okhttp3.*;
+import okhttp3.Call;
+import okhttp3.Dispatcher;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 import okhttp3.internal.http2.StreamResetException;
+
+import static com.firebolt.jdbc.connection.settings.FireboltQueryParameterKey.DEFAULT_FORMAT;
+import static com.firebolt.jdbc.connection.settings.FireboltQueryParameterKey.OUTPUT_FORMAT;
+import static com.firebolt.jdbc.connection.settings.FireboltQueryParameterKey.QUERY_LABEL;
+import static com.firebolt.jdbc.exception.ExceptionType.INVALID_REQUEST;
+import static com.firebolt.jdbc.exception.ExceptionType.UNAUTHORIZED;
+import static java.lang.String.format;
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
+import static java.util.Optional.ofNullable;
 
 @CustomLog
 public class StatementClientImpl extends FireboltClient implements StatementClient {
 
-	private static final boolean DO_NOT_VALIDATE_CONNECTION = false;
+	private static final boolean DO_NOT_VALIDATE_CONNECTION_FLAG = false;
 
 	private static final String TAB_SEPARATED_WITH_NAMES_AND_TYPES_FORMAT = "TabSeparatedWithNamesAndTypes";
 	private static final Map<Pattern, String> missConfigurationErrorMessages = Map.of(
@@ -350,7 +362,7 @@ public class StatementClientImpl extends FireboltClient implements StatementClie
 			}
 			for (String header : response.headers(HEADER_UPDATE_PARAMETER)) {
 				String[] keyValue = header.split("=");
-				connection.addProperty(keyValue[0].trim(), keyValue[1].trim(), DO_NOT_VALIDATE_CONNECTION);
+				connection.addProperty(keyValue[0].trim(), keyValue[1].trim(), DO_NOT_VALIDATE_CONNECTION_FLAG);
 			}
 		}
 	}

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
@@ -144,10 +144,10 @@ class FireboltConnectionServiceSecretTest extends FireboltConnectionTest {
             // by default, it will validate the connection
             connection.addProperty("newProperty", "new value");
 
-            // verify no calls are made on the connection
+            // verify calls are made on the connection
             verify(fireboltStatementService).execute(any(), any(FireboltProperties.class), any(FireboltStatement.class));
 
-            // initial additional property should still be there
+            // initial additional property should be there
             assertEquals("new value", connection.getSessionProperties().getAdditionalProperties().get("newProperty"));
         }
     }
@@ -164,7 +164,7 @@ class FireboltConnectionServiceSecretTest extends FireboltConnectionTest {
             // verify no calls are made on the connection
             verify(fireboltStatementService, never()).execute(any(), any(FireboltProperties.class), any(FireboltStatement.class));
 
-            // initial additional property should still be there
+            // initial additional property should be there
             assertEquals("new value", connection.getSessionProperties().getAdditionalProperties().get("newProperty"));
         }
     }

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
@@ -5,16 +5,17 @@ import com.firebolt.jdbc.client.gateway.GatewayUrlResponse;
 import com.firebolt.jdbc.connection.settings.FireboltProperties;
 import com.firebolt.jdbc.exception.FireboltException;
 import com.firebolt.jdbc.service.FireboltGatewayUrlService;
+import com.firebolt.jdbc.statement.FireboltStatement;
 import com.firebolt.jdbc.type.ParserVersion;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mockito;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toMap;
@@ -22,11 +23,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -104,6 +107,66 @@ class FireboltConnectionServiceSecretTest extends FireboltConnectionTest {
     void shouldNotFetchTokenNorEngineHostForLocalFirebolt() throws SQLException {
         super.shouldNotFetchTokenNorEngineHostForLocalFirebolt();
         verifyNoInteractions(fireboltEngineService);
+    }
+
+    @Test
+    void resettingTheConnectionWouldNotValidateTheConnection() throws SQLException {
+        connectionProperties.put("initialRuntimeParam1", "initialParam1Value");
+
+        try (FireboltConnection connection = createConnection(SYSTEM_ENGINE_URL, connectionProperties)) {
+            assertEquals("initialParam1Value", connection.getSessionProperties().getAdditionalProperties().get("initialRuntimeParam1"));
+
+            connection.addProperty("additionalRuntimeParam1", "runtimeParam1");
+            assertEquals("runtimeParam1", connection.getSessionProperties().getAdditionalProperties().get("additionalRuntimeParam1") );
+
+            // part of the connection there are some calls to the firebolt statements, so reset the mocks before calling reset
+            Mockito.reset(fireboltStatementService);
+
+            connection.reset();
+
+            // verify no calls are made on the connection
+            verify(fireboltStatementService, never()).execute(any(), any(FireboltProperties.class), any(FireboltStatement.class));
+
+            // runtime properties should be cleared
+            assertNull(connection.getSessionProperties().getAdditionalProperties().get("additionalRuntimeParam1"));
+
+            // initial additional property should still be there
+            assertEquals("initialParam1Value", connection.getSessionProperties().getAdditionalProperties().get("initialRuntimeParam1"));
+        }
+    }
+
+    @Test
+    void canAddPropertyThatWillValidateConnection() throws SQLException {
+        try (FireboltConnection connection = createConnection(SYSTEM_ENGINE_URL, connectionProperties)) {
+            // part of the connection there are some calls to the firebolt statements, so reset the mocks before calling reset
+            Mockito.reset(fireboltStatementService);
+
+            // by default, it will validate the connection
+            connection.addProperty("newProperty", "new value");
+
+            // verify no calls are made on the connection
+            verify(fireboltStatementService).execute(any(), any(FireboltProperties.class), any(FireboltStatement.class));
+
+            // initial additional property should still be there
+            assertEquals("new value", connection.getSessionProperties().getAdditionalProperties().get("newProperty"));
+        }
+    }
+
+    @Test
+    void canAddPropertyThatWillNotValidateConnection() throws SQLException {
+        try (FireboltConnection connection = createConnection(SYSTEM_ENGINE_URL, connectionProperties)) {
+            // part of the connection there are some calls to the firebolt statements, so reset the mocks before calling reset
+            Mockito.reset(fireboltStatementService);
+
+            // do not validate the connection
+            connection.addProperty("newProperty", "new value", false);
+
+            // verify no calls are made on the connection
+            verify(fireboltStatementService, never()).execute(any(), any(FireboltProperties.class), any(FireboltStatement.class));
+
+            // initial additional property should still be there
+            assertEquals("new value", connection.getSessionProperties().getAdditionalProperties().get("newProperty"));
+        }
     }
 
     protected FireboltConnection createConnection(String url, Properties props) throws SQLException {


### PR DESCRIPTION
Some API calls to the server return response headers that we need to set on the connection. 

When setting those connection properties, we are currently validating the connection by making a SELECT 1 statement call. (Same happens for reset call)

There are 2 problems:
 1. we should trust the parameter headers that come from the server and should not do additional validation when setting the property
 2. when we the server mentions that the connection needs to be reset we are clearing the properties and also validate the connection. The problem is that we do the SELECT 1 on the system engine url and not on the user engine url.

