### PR TITLE
Fir 44260 reduce the number of requests during the connection establishing part2

### DIFF
--- a/src/integrationTest/java/integration/IntegrationTest.java
+++ b/src/integrationTest/java/integration/IntegrationTest.java
@@ -11,6 +11,7 @@ import java.sql.Statement;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.CustomLog;
@@ -49,6 +50,15 @@ public abstract class IntegrationTest {
 
 	protected Connection createConnection(String engine) throws SQLException {
 		return createConnection(engine, new HashMap<>());
+	}
+
+	protected Connection createConnection(String engine, String database) throws SQLException {
+		ConnectionInfo current = integration.ConnectionInfo.getInstance();
+		ConnectionInfo updated = new ConnectionInfo(current.getPrincipal(), current.getSecret(),
+				current.getEnv(), database, current.getAccount(), engine, current.getApi(), Collections.emptyMap());
+		return DriverManager.getConnection(updated.toJdbcUrl(),
+				integration.ConnectionInfo.getInstance().getPrincipal(),
+				integration.ConnectionInfo.getInstance().getSecret());
 	}
 
 	protected Connection createConnection(String engine, Map<String, String> extra) throws SQLException {

--- a/src/integrationTest/java/integration/tests/CachedConnectionTest.java
+++ b/src/integrationTest/java/integration/tests/CachedConnectionTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CachedConnectionTest extends IntegrationTest {
@@ -18,18 +20,20 @@ public class CachedConnectionTest extends IntegrationTest {
 
     @BeforeAll
     void beforeAll() {
-        executeStatementFromFile("/statements/cache-connection/ddl.sql");
+        executeStatementFromFile("/statements/cached-connection/ddl.sql");
     }
 
     @AfterAll
     void afterEach() {
-        executeStatementFromFile("/statements/cache-connection/cleanup.sql");
+        executeStatementFromFile("/statements/cached-connection/cleanup.sql");
     }
 
     @Test
     @Tag("v2")
     @Tag("slow")
     void createTwoConnections() throws SQLException {
+        String testStartTime = getCurrentUTCTime();
+
         // create a connection on the first engine and database
         try (Connection connection = createConnection()) {
             ResultSet rs = connection.createStatement().executeQuery("SELECT 101");
@@ -47,13 +51,53 @@ public class CachedConnectionTest extends IntegrationTest {
             ResultSet rs = connection.createStatement().executeQuery("SELECT 103");
             assertTrue(rs.next());
 
-            sle
+            // wait for the query history to propagate
+            sleepForMillis(10000);
+
+            // check that the connection cached was using the correct connection to the db and engine
+            String queryHistoryQueryFormat = """
+				SELECT query_text
+				FROM information_schema.engine_query_history
+				WHERE submitted_time > '%s' and status = 'STARTED_EXECUTION' and (query_text='SELECT 101;' or query_text='SELECT 103;')
+				order by submitted_time desc
+			""";
+            ResultSet engineOneResultSet = connection.createStatement().executeQuery(String.format(queryHistoryQueryFormat, testStartTime));
+            assertTrue(engineOneResultSet.next());
+            assertEquals("SELECT 103;", engineOneResultSet.getString(1));
+
+            assertTrue(engineOneResultSet.next());
+            assertEquals("SELECT 101;", engineOneResultSet.getString(1));
+
+            assertFalse(engineOneResultSet.next());
+
         }
 
         // create a connection on the second engine and database
         try (Connection connection = createConnection(CACHED_TEST_ENGINE_NAME, CACHED_TEST_DATABASE_NAME)) {
             ResultSet rs = connection.createStatement().executeQuery("SELECT 104");
             assertTrue(rs.next());
+
+            // wait for the query history to propagate
+            sleepForMillis(10000);
+
+            // check that the connection cached was using the correct connection to the db and engine
+            String queryHistoryQueryFormat = """
+				SELECT query_text
+				FROM information_schema.engine_query_history
+				WHERE submitted_time > '%s' and status = 'STARTED_EXECUTION' and (query_text='SELECT 102;' or query_text='SELECT 104;')
+				order by submitted_time desc
+			""";
+
+            ResultSet engineTwoResultSet = connection.createStatement().executeQuery(String.format(queryHistoryQueryFormat, testStartTime));
+            assertTrue(engineTwoResultSet.next());
+            assertEquals("SELECT 104;", engineTwoResultSet.getString(1));
+
+            assertTrue(engineTwoResultSet.next());
+            assertEquals("SELECT 102;", engineTwoResultSet.getString(1));
+
+            assertFalse(engineTwoResultSet.next());
+
+
         }
 
 

--- a/src/integrationTest/java/integration/tests/CachedConnectionTest.java
+++ b/src/integrationTest/java/integration/tests/CachedConnectionTest.java
@@ -1,0 +1,62 @@
+package integration.tests;
+
+import integration.IntegrationTest;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CachedConnectionTest extends IntegrationTest {
+
+    private static final String CACHED_TEST_ENGINE_NAME = "cached_test_second_engine";
+    private static final String CACHED_TEST_DATABASE_NAME = "cached_test_second_db";
+
+    @BeforeAll
+    void beforeAll() {
+        executeStatementFromFile("/statements/cache-connection/ddl.sql");
+    }
+
+    @AfterAll
+    void afterEach() {
+        executeStatementFromFile("/statements/cache-connection/cleanup.sql");
+    }
+
+    @Test
+    @Tag("v2")
+    @Tag("slow")
+    void createTwoConnections() throws SQLException {
+        // create a connection on the first engine and database
+        try (Connection connection = createConnection()) {
+            ResultSet rs = connection.createStatement().executeQuery("SELECT 101");
+            assertTrue(rs.next());
+        }
+
+        // create a connection on the second engine and database
+        try (Connection connection = createConnection(CACHED_TEST_ENGINE_NAME, CACHED_TEST_DATABASE_NAME)) {
+            ResultSet rs = connection.createStatement().executeQuery("SELECT 102");
+            assertTrue(rs.next());
+        }
+
+        // create a connection back on the first engine and database
+        try (Connection connection = createConnection()) {
+            ResultSet rs = connection.createStatement().executeQuery("SELECT 103");
+            assertTrue(rs.next());
+
+            sle
+        }
+
+        // create a connection on the second engine and database
+        try (Connection connection = createConnection(CACHED_TEST_ENGINE_NAME, CACHED_TEST_DATABASE_NAME)) {
+            ResultSet rs = connection.createStatement().executeQuery("SELECT 104");
+            assertTrue(rs.next());
+        }
+
+
+    }
+
+}

--- a/src/integrationTest/java/integration/tests/ConnectionTest.java
+++ b/src/integrationTest/java/integration/tests/ConnectionTest.java
@@ -237,11 +237,7 @@ class ConnectionTest extends IntegrationTest {
                 }
                 // sleep for 10s to give QH time to get populated and avoid flakiness
                 // it sometime takes that long
-                try {
-                    Thread.sleep(10000);
-                } catch (InterruptedException e) {
-                    // ignore
-                }
+                sleepForMillis(10000);
 
                 // Validate we've only executed one insert
                 String qhQuery = "SELECT count(*) from information_schema.engine_query_history WHERE status='ENDED_SUCCESSFULLY' " +

--- a/src/integrationTest/resources/statements/cached-connection/cleanup.sql
+++ b/src/integrationTest/resources/statements/cached-connection/cleanup.sql
@@ -1,3 +1,4 @@
 DROP TABLE IF EXISTS statement_test CASCADE;
+STOP ENGINE cached_test_second_engine WITH TERMINATE=true;
 DROP ENGINE IF EXISTS cached_test_second_engine;
 DROP DATABASE IF EXISTS cached_test_second_db;

--- a/src/integrationTest/resources/statements/cached-connection/cleanup.sql
+++ b/src/integrationTest/resources/statements/cached-connection/cleanup.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS statement_test CASCADE;
+DROP ENGINE IF EXISTS cached_test_second_engine;
+DROP DATABASE IF EXISTS cached_test_second_db;

--- a/src/integrationTest/resources/statements/cached-connection/ddl.sql
+++ b/src/integrationTest/resources/statements/cached-connection/ddl.sql
@@ -1,0 +1,10 @@
+DROP TABLE IF EXISTS statement_test;
+CREATE
+FACT TABLE IF NOT EXISTS statement_test (
+id              LONG
+)
+PRIMARY INDEX id;
+CREATE ENGINE IF NOT EXISTS cached_test_second_engine;
+CREATE DATABASE IF NOT EXISTS cached_test_second_db;
+
+

--- a/src/main/java/com/firebolt/jdbc/client/query/StatementClient.java
+++ b/src/main/java/com/firebolt/jdbc/client/query/StatementClient.java
@@ -1,12 +1,12 @@
 package com.firebolt.jdbc.client.query;
 
-import com.firebolt.jdbc.connection.settings.FireboltProperties;
-import com.firebolt.jdbc.statement.StatementInfoWrapper;
-
 import java.io.InputStream;
 import java.sql.SQLException;
 
-public interface StatementClient {
+import com.firebolt.jdbc.connection.settings.FireboltProperties;
+import com.firebolt.jdbc.statement.StatementInfoWrapper;
+
+public interface  StatementClient {
 
 	/**
 	 * Post SQL statement

--- a/src/main/java/com/firebolt/jdbc/service/FireboltEngineVersion2Service.java
+++ b/src/main/java/com/firebolt/jdbc/service/FireboltEngineVersion2Service.java
@@ -1,19 +1,41 @@
 package com.firebolt.jdbc.service;
 
-import com.firebolt.jdbc.connection.Engine;
-import com.firebolt.jdbc.connection.FireboltConnection;
-import com.firebolt.jdbc.connection.settings.FireboltProperties;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import static java.lang.String.format;
+import com.firebolt.jdbc.connection.Engine;
+import com.firebolt.jdbc.connection.FireboltConnection;
+import com.firebolt.jdbc.connection.settings.FireboltProperties;
 
+import lombok.extern.slf4j.Slf4j;
+import net.jodah.expiringmap.ExpiringMap;
+
+@Slf4j
 public class FireboltEngineVersion2Service implements FireboltEngineService {
+    private static final long DEFAULT_CACHED_VERIFIED_DATABASES_IN_SECONDS = 15;
+    private static final long DEFAULT_CACHED_VERIFIED_ENGINES_IN_SECONDS = 15;
+
+    private static final ExpiringMap<String, String> CACHED_VERIFIED_DATABASES = ExpiringMap.builder()
+            .variableExpiration().build();
+    private static final ExpiringMap<String, String> CACHED_VERIFIED_ENGINES = ExpiringMap.builder()
+            .variableExpiration().build();
+
     private final FireboltConnection fireboltConnection;
+    private final long cacheDatabaseDurationInSeconds;
+    private final long cacheEngineDurationInSeconds;
 
     public FireboltEngineVersion2Service(FireboltConnection fireboltConnection) {
+        this(fireboltConnection, DEFAULT_CACHED_VERIFIED_DATABASES_IN_SECONDS, DEFAULT_CACHED_VERIFIED_ENGINES_IN_SECONDS);
+    }
+
+    // visible for testing
+    FireboltEngineVersion2Service(FireboltConnection fireboltConnection, long cachedDatabaseDuration, long cachedEngineDuration) {
         this.fireboltConnection = fireboltConnection;
+        this.cacheDatabaseDurationInSeconds = cachedDatabaseDuration;
+        this.cacheEngineDurationInSeconds = cachedEngineDuration;
     }
 
     @Override
@@ -21,16 +43,55 @@ public class FireboltEngineVersion2Service implements FireboltEngineService {
     public Engine getEngine(FireboltProperties properties) throws SQLException {
         try (Statement statement = fireboltConnection.createStatement()) {
             if (properties.getDatabase() != null) {
-                statement.executeUpdate(use("DATABASE", properties.getDatabase()));
+                verifyDatabaseExists(statement, properties.getHost(), properties.getDatabase());
             }
-            statement.executeUpdate(use("ENGINE", properties.getEngine()));
+            verifyEngineExists(statement, properties.getHost(), properties.getEngine());
         }
         // now session properties are updated with new database and engine
         FireboltProperties sessionProperties = fireboltConnection.getSessionProperties();
         return new Engine(fireboltConnection.getEndpoint(), null, sessionProperties.getEngine(), sessionProperties.getDatabase(), null);
     }
 
+    /**
+     * We are caching the database names for some time and if we had checked it before assumed that it is still valid.
+     *
+     * @param databaseName
+     */
+    private void verifyDatabaseExists(Statement statement, String host, String databaseName) throws SQLException {
+        synchronized (CACHED_VERIFIED_DATABASES) {
+            if (CACHED_VERIFIED_DATABASES.containsKey(asCacheKey(host, databaseName))) {
+                log.debug("Using cache verification of database");
+                return;
+            }
+
+            statement.executeUpdate(use("DATABASE", databaseName));
+            CACHED_VERIFIED_DATABASES.put(asCacheKey(host, databaseName), "verified", cacheDatabaseDurationInSeconds, SECONDS);
+        }
+    }
+
+    /**
+     * We are caching the database names for 15 mins and if we had checked it before assumed that it is still valid.
+     *
+     * @param engineName
+     */
+    private void verifyEngineExists(Statement statement, String host, String engineName) throws SQLException {
+        synchronized (CACHED_VERIFIED_ENGINES) {
+            if (CACHED_VERIFIED_ENGINES.containsKey(asCacheKey(host, engineName))) {
+                log.debug("Using cache verification of engine");
+                return;
+            }
+
+            statement.executeUpdate(use("ENGINE", engineName));
+            CACHED_VERIFIED_ENGINES.put(asCacheKey(host, engineName), "verified", cacheEngineDurationInSeconds, SECONDS);
+        }
+
+    }
+
     private String use(String entity, String name) {
         return format("USE %s \"%s\"", entity, name);
+    }
+
+    private String asCacheKey(String host, String databaseName) {
+        return new StringBuilder(host).append(":").append(databaseName).toString();
     }
 }

--- a/src/main/java/com/firebolt/jdbc/service/FireboltEngineVersion2Service.java
+++ b/src/main/java/com/firebolt/jdbc/service/FireboltEngineVersion2Service.java
@@ -48,9 +48,9 @@ public class FireboltEngineVersion2Service implements FireboltEngineService {
     public Engine getEngine(FireboltProperties properties) throws SQLException {
         try (Statement statement = fireboltConnection.createStatement()) {
             if (properties.getDatabase() != null) {
-                verifyDatabaseExists(statement, properties.getHost(), properties.getDatabase());
+                getAndSetDatabaseProperties(statement, properties.getHost(), properties.getDatabase());
             }
-            verifyEngineExists(statement, properties.getHost(), properties.getEngine());
+            getAndSetEngineProperties(statement, properties.getHost(), properties.getEngine());
         }
         // now session properties are updated with new database and engine
         FireboltProperties sessionProperties = fireboltConnection.getSessionProperties();
@@ -66,7 +66,7 @@ public class FireboltEngineVersion2Service implements FireboltEngineService {
      * @param host - the system engine url
      * @param databaseName - the name of the database to check
      */
-    private void verifyDatabaseExists(Statement statement, String host, String databaseName) throws SQLException {
+    private void getAndSetDatabaseProperties(Statement statement, String host, String databaseName) throws SQLException {
         synchronized (CACHED_VERIFIED_DATABASES) {
 
             if (CACHED_VERIFIED_DATABASES.containsKey(asCacheKey(host, databaseName))) {
@@ -100,7 +100,7 @@ public class FireboltEngineVersion2Service implements FireboltEngineService {
      * @param engineName - the name of the engine to check
 
      */
-    private void verifyEngineExists(Statement statement, String host, String engineName) throws SQLException {
+    private void getAndSetEngineProperties(Statement statement, String host, String engineName) throws SQLException {
         synchronized (CACHED_VERIFIED_ENGINES) {
             if (CACHED_VERIFIED_ENGINES.containsKey(asCacheKey(host, engineName))) {
                 log.debug("Using cache verification of engine");

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
@@ -164,7 +164,7 @@ class FireboltConnectionServiceSecretTest extends FireboltConnectionTest {
             // verify no calls are made on the connection
             verify(fireboltStatementService, never()).execute(any(), any(FireboltProperties.class), any(FireboltStatement.class));
 
-            // initial additional property should be there
+            // initial additional property should still be there
             assertEquals("new value", connection.getSessionProperties().getAdditionalProperties().get("newProperty"));
         }
     }

--- a/src/test/java/com/firebolt/jdbc/service/FireboltEngineVersion2ServiceTest.java
+++ b/src/test/java/com/firebolt/jdbc/service/FireboltEngineVersion2ServiceTest.java
@@ -3,32 +3,48 @@ package com.firebolt.jdbc.service;
 import com.firebolt.jdbc.connection.Engine;
 import com.firebolt.jdbc.connection.FireboltConnection;
 import com.firebolt.jdbc.connection.settings.FireboltProperties;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.Properties;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class FireboltEngineVersion2ServiceTest {
+
+    private static final long ONE_SECOND = 1;
+
+    private static final String MY_ENGINE = "my_engine";
+    private static final String YOUR_ENGINE = "your_engine";
+
+    private static final String MY_DATABASE = "my_database";
+    private static final String YOUR_DATABASE = "your_database";
+
+    private static final String MY_ENGINE_ENDPOINT = "api.region.firebolt.io";;
+    private static final String YOUR_ENGINE_ENDPOINT = "api2.region.firebolt.io";;
+
+    private static final String SYSTEM_ENGINE_URL = "system.engine.url";
+
     @ParameterizedTest(name = "database={0}")
-    @ValueSource(strings = {"my_database"})
+    @ValueSource(strings = {MY_DATABASE})
     @NullSource
-    void getEndine(String database) throws SQLException {
-        String engine = "my_engine";
+    void getEngine(String database) throws SQLException {
         Properties props = new Properties();
         if (database != null) {
             props.setProperty("database", database);
         }
-        props.setProperty("engine", engine);
-        String endpoint = "api.region.firebolt.io";
+        props.setProperty("engine", MY_ENGINE);
         FireboltProperties properties = new FireboltProperties(props);
         FireboltConnection connection = mock(FireboltConnection.class);
         Statement statement = mock(Statement.class);
@@ -38,12 +54,199 @@ class FireboltEngineVersion2ServiceTest {
         } else {
             verify(statement, never()).executeQuery("USE DATABASE " + database);
         }
-        when(statement.executeUpdate("USE ENGINE " + engine)).thenReturn(1);
+        when(statement.executeUpdate("USE ENGINE " + MY_ENGINE)).thenReturn(1);
         when(connection.getSessionProperties()).thenReturn(properties);
-        when(connection.getEndpoint()).thenReturn(endpoint);
+        when(connection.getEndpoint()).thenReturn(MY_ENGINE_ENDPOINT);
 
         FireboltEngineVersion2Service  service = new FireboltEngineVersion2Service(connection);
         Engine actualEngine = service.getEngine(properties);
-        assertEquals(new Engine(endpoint, null, engine, database, null), actualEngine);
+        assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, database, null), actualEngine);
     }
+
+    @Test
+    void canGetDatabaseAndEngineFromCache() throws SQLException {
+        Properties props = new Properties();
+        props.setProperty("database", MY_DATABASE);
+        props.setProperty("engine", MY_ENGINE);
+
+        // we cache based on system engine url and the database/engine
+        String host = SYSTEM_ENGINE_URL + RandomStringUtils.randomNumeric(5);
+        props.setProperty("host", host);
+
+        FireboltProperties properties = new FireboltProperties(props);
+
+        FireboltConnection firstConnection = mock(FireboltConnection.class);
+        Statement statementFromFirstConnection = mock(Statement.class);
+        when(firstConnection.createStatement()).thenReturn(statementFromFirstConnection);
+        when(statementFromFirstConnection.executeUpdate("USE DATABASE " + MY_DATABASE)).thenReturn(1);
+        when(statementFromFirstConnection.executeUpdate("USE ENGINE " + MY_ENGINE)).thenReturn(1);
+        when(firstConnection.getSessionProperties()).thenReturn(properties);
+        when(firstConnection.getEndpoint()).thenReturn(MY_ENGINE_ENDPOINT);
+
+        FireboltEngineVersion2Service service = new FireboltEngineVersion2Service(firstConnection);
+        Engine actualEngine = service.getEngine(properties);
+        assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, MY_DATABASE, null), actualEngine);
+
+        // should not execute any caching
+        verify(statementFromFirstConnection).executeUpdate("USE DATABASE \"" + MY_DATABASE + "\"");
+        verify(statementFromFirstConnection).executeUpdate("USE ENGINE \"" + MY_ENGINE + "\"");
+
+        Properties secondProps = new Properties();
+        secondProps.setProperty("database", MY_DATABASE);
+        secondProps.setProperty("engine", MY_ENGINE);
+        secondProps.setProperty("host", host);
+
+        FireboltProperties secondConnectionProperties = new FireboltProperties(secondProps);
+
+        FireboltConnection secondConnection = mock(FireboltConnection.class);
+        when(secondConnection.getSessionProperties()).thenReturn(secondConnectionProperties);
+
+        Statement statementFromSecondConnection = mock(Statement.class);
+        when(secondConnection.createStatement()).thenReturn(statementFromSecondConnection);
+        when(secondConnection.getSessionProperties()).thenReturn(secondConnectionProperties);
+        when(secondConnection.getEndpoint()).thenReturn(MY_ENGINE_ENDPOINT);
+
+        doNothing().when(secondConnection).addProperty(anyString(), anyString());
+        doNothing().when(secondConnection).setEndpoint(anyString());
+
+        service = new FireboltEngineVersion2Service(secondConnection);
+        Engine actualEngineFromCache = service.getEngine(secondConnectionProperties);
+        assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, MY_DATABASE, null), actualEngineFromCache);
+
+        // should not execute any statements
+        verify(statementFromSecondConnection, never()).executeUpdate("USE DATABASE \"" + MY_DATABASE + "\"");
+        verify(statementFromSecondConnection, never()).executeUpdate("USE ENGINE \"" + MY_ENGINE + "\"");
+
+        // we should have the database and the engine set on the properties
+        assertEquals(MY_DATABASE, secondConnection.getSessionProperties().getDatabase());
+        assertEquals(MY_ENGINE, secondConnection.getSessionProperties().getEngine());
+    }
+
+    @Test
+    void canGetDatabaseAndEngineFromSourceWhenCacheExpired() throws SQLException {
+        Properties props = new Properties();
+        props.setProperty("database", MY_DATABASE);
+        props.setProperty("engine", MY_ENGINE);
+
+        // we cache based on system engine url and the database/engine
+        String host = SYSTEM_ENGINE_URL + RandomStringUtils.randomNumeric(5);
+        props.setProperty("host", host);
+
+        FireboltProperties properties = new FireboltProperties(props);
+
+        FireboltConnection firstConnection = mock(FireboltConnection.class);
+        Statement statementFromFirstConnection = mock(Statement.class);
+        when(firstConnection.createStatement()).thenReturn(statementFromFirstConnection);
+        when(statementFromFirstConnection.executeUpdate("USE DATABASE " + MY_DATABASE)).thenReturn(1);
+        when(statementFromFirstConnection.executeUpdate("USE ENGINE " + MY_ENGINE)).thenReturn(1);
+        when(firstConnection.getSessionProperties()).thenReturn(properties);
+        when(firstConnection.getEndpoint()).thenReturn(MY_ENGINE_ENDPOINT);
+
+        // keep the values in cache for only 1 second
+        FireboltEngineVersion2Service service = new FireboltEngineVersion2Service(firstConnection, ONE_SECOND, ONE_SECOND);
+        Engine actualEngine = service.getEngine(properties);
+        assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, MY_DATABASE, null), actualEngine);
+
+        verify(statementFromFirstConnection).executeUpdate("USE DATABASE \"" + MY_DATABASE + "\"");
+        verify(statementFromFirstConnection).executeUpdate("USE ENGINE \"" + MY_ENGINE + "\"");
+
+        // sleep for 2 seconds just to make sure the cache expired
+        sleepForMillis(TimeUnit.SECONDS.toMillis(2));
+
+        Properties secondProps = new Properties();
+        secondProps.setProperty("database", MY_DATABASE);
+        secondProps.setProperty("engine", MY_ENGINE);
+        secondProps.setProperty("host", host);
+
+        FireboltProperties secondConnectionProperties = new FireboltProperties(secondProps);
+
+        FireboltConnection secondConnection = mock(FireboltConnection.class);
+        when(secondConnection.getSessionProperties()).thenReturn(secondConnectionProperties);
+
+        Statement statementFromSecondConnection = mock(Statement.class);
+        when(secondConnection.createStatement()).thenReturn(statementFromSecondConnection);
+        when(secondConnection.getSessionProperties()).thenReturn(secondConnectionProperties);
+        when(secondConnection.getEndpoint()).thenReturn(MY_ENGINE_ENDPOINT);
+        when(statementFromSecondConnection.executeUpdate("USE DATABASE " + MY_DATABASE)).thenReturn(1);
+        when(statementFromSecondConnection.executeUpdate("USE ENGINE " + MY_ENGINE)).thenReturn(1);
+
+        doNothing().when(secondConnection).addProperty(anyString(), anyString());
+        doNothing().when(secondConnection).setEndpoint(anyString());
+
+        service = new FireboltEngineVersion2Service(secondConnection);
+        Engine actualEngineFromCache = service.getEngine(secondConnectionProperties);
+        assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, MY_DATABASE, null), actualEngineFromCache);
+
+        // should not execute any caching
+        verify(statementFromSecondConnection).executeUpdate("USE DATABASE \"" + MY_DATABASE + "\"");
+        verify(statementFromSecondConnection).executeUpdate("USE ENGINE \"" + MY_ENGINE + "\"");
+
+        // we should have the database and the engine set on the properties
+        assertEquals(MY_DATABASE, secondConnection.getSessionProperties().getDatabase());
+        assertEquals(MY_ENGINE, secondConnection.getSessionProperties().getEngine());
+    }
+
+    @Test
+    void canGetDatabaseAndEngineFromSourceWhenDifferentDatabaseAndEngineAreCached() throws SQLException {
+        Properties props = new Properties();
+        props.setProperty("database", MY_DATABASE);
+        props.setProperty("engine", MY_ENGINE);
+
+        // we cache based on system engine url and the database/engine
+        String host = SYSTEM_ENGINE_URL + RandomStringUtils.randomNumeric(5);
+        props.setProperty("host", host);
+
+        FireboltProperties properties = new FireboltProperties(props);
+
+        FireboltConnection firstConnection = mock(FireboltConnection.class);
+        Statement statementFromFirstConnection = mock(Statement.class);
+        when(firstConnection.createStatement()).thenReturn(statementFromFirstConnection);
+        when(statementFromFirstConnection.executeUpdate("USE DATABASE " + MY_DATABASE)).thenReturn(1);
+        when(statementFromFirstConnection.executeUpdate("USE ENGINE " + MY_ENGINE)).thenReturn(1);
+        when(firstConnection.getSessionProperties()).thenReturn(properties);
+        when(firstConnection.getEndpoint()).thenReturn(MY_ENGINE_ENDPOINT);
+
+        FireboltEngineVersion2Service service = new FireboltEngineVersion2Service(firstConnection);
+        Engine actualEngine = service.getEngine(properties);
+        assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, MY_DATABASE, null), actualEngine);
+
+        verify(statementFromFirstConnection).executeUpdate("USE DATABASE \"" + MY_DATABASE + "\"");
+        verify(statementFromFirstConnection).executeUpdate("USE ENGINE \"" + MY_ENGINE + "\"");
+
+        // use a diffent database and engine. Values should be obtained from the source
+
+        Properties secondProps = new Properties();
+        secondProps.setProperty("database", YOUR_DATABASE);
+        secondProps.setProperty("engine", YOUR_ENGINE);
+        secondProps.setProperty("host", host);
+
+        FireboltProperties secondConnectionProperties = new FireboltProperties(secondProps);
+
+        FireboltConnection secondConnection = mock(FireboltConnection.class);
+        when(secondConnection.getSessionProperties()).thenReturn(secondConnectionProperties);
+
+        Statement statementFromSecondConnection = mock(Statement.class);
+        when(secondConnection.createStatement()).thenReturn(statementFromSecondConnection);
+        when(secondConnection.getSessionProperties()).thenReturn(secondConnectionProperties);
+        when(secondConnection.getEndpoint()).thenReturn(YOUR_ENGINE_ENDPOINT);
+        when(statementFromSecondConnection.executeUpdate("USE DATABASE " + MY_DATABASE)).thenReturn(1);
+        when(statementFromSecondConnection.executeUpdate("USE ENGINE " + MY_ENGINE)).thenReturn(1);
+
+        service = new FireboltEngineVersion2Service(secondConnection);
+        Engine yourEngine = service.getEngine(secondConnectionProperties);
+        assertEquals(new Engine(YOUR_ENGINE_ENDPOINT, null, YOUR_ENGINE, YOUR_DATABASE, null), yourEngine);
+
+        verify(statementFromSecondConnection).executeUpdate("USE DATABASE \"" + YOUR_DATABASE + "\"");
+        verify(statementFromSecondConnection).executeUpdate("USE ENGINE \"" + YOUR_ENGINE + "\"");
+    }
+
+    private void sleepForMillis(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            // do nothing
+        }
+    }
+
+
 }


### PR DESCRIPTION
Part2 
- cache the response for the use database and use engine calls
- for now we know what are the parameters that the server sends back so we keep those results in cache and update those values when we get the connection from cache. We also need to update the value for the endpoint after we do a use engine since next calls should use the user engine. 