### PR TITLE
FIR-43922: refactored a bit the connection creation

### DIFF
--- a/src/main/java/com/firebolt/FireboltDriver.java
+++ b/src/main/java/com/firebolt/FireboltDriver.java
@@ -1,11 +1,9 @@
 package com.firebolt;
 
-import com.firebolt.jdbc.connection.FireboltConnection;
+import com.firebolt.jdbc.connection.FireboltConnectionProvider;
 import com.firebolt.jdbc.exception.FireboltSQLFeatureNotSupportedException;
 import com.firebolt.jdbc.util.PropertyUtil;
 import com.firebolt.jdbc.util.VersionUtil;
-import lombok.CustomLog;
-
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverPropertyInfo;
@@ -13,6 +11,7 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
 import java.util.logging.Logger;
+import lombok.CustomLog;
 
 @CustomLog
 public class FireboltDriver implements Driver {
@@ -28,9 +27,20 @@ public class FireboltDriver implements Driver {
 		}
 	}
 
+	private FireboltConnectionProvider fireboltConnectionProvider;
+
+	public FireboltDriver() {
+		this(new FireboltConnectionProvider());
+	}
+
+	// visilble for testing
+	FireboltDriver(FireboltConnectionProvider fireboltConnectionProvider) {
+		this.fireboltConnectionProvider = fireboltConnectionProvider;
+	}
+
 	@Override
 	public Connection connect(String url, Properties connectionSettings) throws SQLException {
-		return acceptsURL(url) ? FireboltConnection.create(url, connectionSettings) : null;
+		return acceptsURL(url) ? fireboltConnectionProvider.create(url, connectionSettings) : null;
 	}
 
 	@Override

--- a/src/main/java/com/firebolt/jdbc/connection/Authenticator.java
+++ b/src/main/java/com/firebolt/jdbc/connection/Authenticator.java
@@ -1,0 +1,12 @@
+package com.firebolt.jdbc.connection;
+
+import java.sql.SQLException;
+
+/**
+ * Class that knows to authenticate to Firebolt
+ */
+public interface Authenticator {
+
+    void authenticate() throws SQLException;
+
+}

--- a/src/main/java/com/firebolt/jdbc/connection/ClientIdAndSecretAuthenticator.java
+++ b/src/main/java/com/firebolt/jdbc/connection/ClientIdAndSecretAuthenticator.java
@@ -1,0 +1,15 @@
+package com.firebolt.jdbc.connection;
+
+import java.sql.SQLException;
+
+/**
+ * Uses client id and client secret to authenticate to firebolt
+ */
+public class ClientIdAndSecretAuthenticator implements Authenticator {
+
+    @Override
+    public void authenticate() throws SQLException {
+
+    }
+
+}

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnection.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnection.java
@@ -23,11 +23,6 @@ import com.firebolt.jdbc.type.array.FireboltArray;
 import com.firebolt.jdbc.type.lob.FireboltBlob;
 import com.firebolt.jdbc.type.lob.FireboltClob;
 import com.firebolt.jdbc.util.PropertyUtil;
-import lombok.CustomLog;
-import lombok.Getter;
-import lombok.NonNull;
-import okhttp3.OkHttpClient;
-
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.sql.Array;
@@ -50,8 +45,8 @@ import java.sql.Struct;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -60,7 +55,10 @@ import java.util.Properties;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
+import lombok.CustomLog;
+import lombok.Getter;
+import lombok.NonNull;
+import okhttp3.OkHttpClient;
 
 import static com.firebolt.jdbc.connection.settings.FireboltSessionProperty.getNonDeprecatedProperties;
 import static java.lang.String.format;
@@ -128,39 +126,6 @@ public abstract class FireboltConnection extends JdbcBase implements Connection,
 	}
 
 	protected abstract FireboltAuthenticationClient createFireboltAuthenticationClient(OkHttpClient httpClient);
-
-	public static FireboltConnection create(@NonNull String url, Properties connectionSettings) throws SQLException {
-		return createConnectionInstance(url, connectionSettings);
-	}
-
-	private static FireboltConnection createConnectionInstance(@NonNull String url, Properties connectionSettings) throws SQLException {
-		switch(getUrlVersion(url, connectionSettings)) {
-			case 1:
-				return new FireboltConnectionUserPassword(url, connectionSettings, ParserVersion.LEGACY);
-			case 2:
-				return new FireboltConnectionServiceSecret(url, connectionSettings, ParserVersion.CURRENT);
-			default: throw new IllegalArgumentException(format("Cannot distinguish version from url %s", url));
-		}
-	}
-
-	private static int getUrlVersion(String url, Properties connectionSettings) {
-		Pattern urlWithHost = Pattern.compile("jdbc:firebolt://api\\.\\w+\\.firebolt\\.io");
-		if (!urlWithHost.matcher(url).find()) {
-			return 2; // new URL format
-		}
-		// old URL format
-		Properties propertiesFromUrl = UrlUtil.extractProperties(url);
-		Properties allSettings = PropertyUtil.mergeProperties(propertiesFromUrl, connectionSettings);
-		if (allSettings.containsKey("client_id") && allSettings.containsKey("client_secret") && !allSettings.containsKey("user") && !allSettings.containsKey("password")) {
-			return 2;
-		}
-		FireboltProperties props = new FireboltProperties(new Properties[] {propertiesFromUrl, connectionSettings});
-		String principal = props.getPrincipal();
-		if (props.getAccessToken() != null || (principal != null && principal.contains("@"))) {
-			return 1;
-		}
-		return 2;
-	}
 
 	protected OkHttpClient getHttpClient(FireboltProperties fireboltProperties) throws SQLException {
 		try {

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionProvider.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionProvider.java
@@ -1,0 +1,87 @@
+package com.firebolt.jdbc.connection;
+
+import com.firebolt.jdbc.connection.settings.FireboltProperties;
+import com.firebolt.jdbc.type.ParserVersion;
+import com.firebolt.jdbc.util.PropertyUtil;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.regex.Pattern;
+import lombok.NonNull;
+
+import static java.lang.String.format;
+
+/**
+ * Based on the connection url and the connection properties this class will generate the correct firebolt connection
+ */
+public class FireboltConnectionProvider {
+
+
+    private FireboltConnectionProviderWrapper fireboltConnectionProviderWrapper;
+
+    public FireboltConnectionProvider() {
+        this(new FireboltConnectionProviderWrapper());
+    }
+
+    // visible for testing
+    FireboltConnectionProvider(FireboltConnectionProviderWrapper fireboltConnectionProviderWrapper) {
+        this.fireboltConnectionProviderWrapper = fireboltConnectionProviderWrapper;
+    }
+
+    /**
+     * From the url and connection properties, determine the appropriate firebolt connection
+     */
+    public FireboltConnection create(@NonNull String url, Properties connectionSettings) throws SQLException {
+        switch(getUrlVersion(url, connectionSettings)) {
+            case 1:
+                return fireboltConnectionProviderWrapper.createFireboltConnectionUsernamePassword(url, connectionSettings, ParserVersion.LEGACY);
+            case 2:
+                return connectToLocalHost(url, connectionSettings) ?
+                        fireboltConnectionProviderWrapper.createLocalhostFireboltConnectionServiceSecret(url, connectionSettings, ParserVersion.CURRENT) :
+                        fireboltConnectionProviderWrapper.createFireboltConnectionServiceSecret(url, connectionSettings, ParserVersion.CURRENT);
+            default: throw new IllegalArgumentException(format("Cannot distinguish version from url %s", url));
+        }
+    }
+
+    private boolean connectToLocalHost(String jdbcUri, Properties connectionProperties) {
+        FireboltProperties fireboltProperties = new FireboltProperties(new Properties[] {UrlUtil.extractProperties(jdbcUri), connectionProperties});
+        return PropertyUtil.isLocalDb(fireboltProperties);
+    }
+
+    private int getUrlVersion(String url, Properties connectionSettings) {
+        Pattern urlWithHost = Pattern.compile("jdbc:firebolt://api\\.\\w+\\.firebolt\\.io");
+        if (!urlWithHost.matcher(url).find()) {
+            return 2; // new URL format
+        }
+        // old URL format
+        Properties propertiesFromUrl = UrlUtil.extractProperties(url);
+        Properties allSettings = PropertyUtil.mergeProperties(propertiesFromUrl, connectionSettings);
+        if (allSettings.containsKey("client_id") && allSettings.containsKey("client_secret") && !allSettings.containsKey("user") && !allSettings.containsKey("password")) {
+            return 2;
+        }
+        FireboltProperties props = new FireboltProperties(new Properties[] {propertiesFromUrl, connectionSettings});
+        String principal = props.getPrincipal();
+        if (props.getAccessToken() != null || (principal != null && principal.contains("@"))) {
+            return 1;
+        }
+        return 2;
+    }
+
+    /**
+     * This is just a wrapper classes for the connection instance creation so we can test them without requiring an actual firebolt 1.0 or firebolt 2.0 backend.
+     */
+    static class FireboltConnectionProviderWrapper {
+
+        public FireboltConnectionUserPassword createFireboltConnectionUsernamePassword(String url, Properties connectionSettings, ParserVersion parserVersion) throws SQLException {
+            return new FireboltConnectionUserPassword(url, connectionSettings, parserVersion);
+        }
+
+        public FireboltConnectionServiceSecret createFireboltConnectionServiceSecret(String url, Properties connectionSettings, ParserVersion parserVersion) throws SQLException {
+            return new FireboltConnectionServiceSecret(url, connectionSettings, parserVersion);
+        }
+
+        public LocalhostFireboltConnectionServiceSecret createLocalhostFireboltConnectionServiceSecret(String url, Properties connectionSettings, ParserVersion parserVersion) throws SQLException {
+            return new LocalhostFireboltConnectionServiceSecret(url, connectionSettings, parserVersion);
+        }
+    }
+
+}

--- a/src/main/java/com/firebolt/jdbc/connection/LocalhostFireboltConnectionServiceSecret.java
+++ b/src/main/java/com/firebolt/jdbc/connection/LocalhostFireboltConnectionServiceSecret.java
@@ -1,0 +1,47 @@
+package com.firebolt.jdbc.connection;
+
+import com.firebolt.jdbc.exception.FireboltException;
+import com.firebolt.jdbc.service.FireboltAuthenticationService;
+import com.firebolt.jdbc.service.FireboltEngineInformationSchemaService;
+import com.firebolt.jdbc.service.FireboltGatewayUrlService;
+import com.firebolt.jdbc.service.FireboltStatementService;
+import com.firebolt.jdbc.type.ParserVersion;
+import java.sql.SQLException;
+import java.util.Properties;
+import lombok.NonNull;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A Connection to firebolt that is using localhost as the url of the firebolt server. It will talk to a firebolt 2.0 server.
+ */
+public class LocalhostFireboltConnectionServiceSecret extends FireboltConnectionServiceSecret {
+
+    LocalhostFireboltConnectionServiceSecret(@NonNull String url, Properties connectionSettings, ParserVersion parserVersion) throws SQLException {
+        super(url, connectionSettings, parserVersion);
+    }
+
+    // visible for testing
+    LocalhostFireboltConnectionServiceSecret(@NonNull String url,
+                                    Properties connectionSettings,
+                                    FireboltAuthenticationService fireboltAuthenticationService,
+                                    FireboltGatewayUrlService fireboltGatewayUrlService,
+                                    FireboltStatementService fireboltStatementService,
+                                    FireboltEngineInformationSchemaService fireboltEngineService,
+                                    ParserVersion parserVersion) throws SQLException {
+        super(url, connectionSettings, fireboltAuthenticationService, fireboltGatewayUrlService, fireboltStatementService, fireboltEngineService, parserVersion);
+    }
+
+
+    /**
+     * For localhost connection only validate the account that is populated
+     *
+     * @throws FireboltException
+     */
+    protected void validateMandatoryConnectionParameters() throws FireboltException {
+        String account = loginProperties.getAccount();
+        if (StringUtils.isBlank(account)) {
+            throw new FireboltException("Cannot connect: account is missing");
+        }
+    }
+
+}

--- a/src/main/java/com/firebolt/jdbc/connection/UsernamePasswordAuthenticator.java
+++ b/src/main/java/com/firebolt/jdbc/connection/UsernamePasswordAuthenticator.java
@@ -1,0 +1,15 @@
+package com.firebolt.jdbc.connection;
+
+import java.sql.SQLException;
+
+/**
+ * Authenticates to firebolt using username/password
+ */
+public class UsernamePasswordAuthenticator implements Authenticator {
+
+    @Override
+    public void authenticate() throws SQLException {
+
+    }
+
+}

--- a/src/main/java/com/firebolt/jdbc/util/PropertyUtil.java
+++ b/src/main/java/com/firebolt/jdbc/util/PropertyUtil.java
@@ -2,9 +2,6 @@ package com.firebolt.jdbc.util;
 
 import com.firebolt.jdbc.connection.settings.FireboltProperties;
 import com.firebolt.jdbc.connection.settings.FireboltSessionProperty;
-import lombok.CustomLog;
-import lombok.experimental.UtilityClass;
-
 import java.sql.DriverPropertyInfo;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
@@ -14,6 +11,8 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.CustomLog;
+import lombok.experimental.UtilityClass;
 
 import static com.firebolt.jdbc.connection.UrlUtil.extractProperties;
 import static com.firebolt.jdbc.connection.settings.FireboltSessionProperty.getNonDeprecatedProperties;

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionProviderTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionProviderTest.java
@@ -1,0 +1,141 @@
+package com.firebolt.jdbc.connection;
+
+import com.firebolt.jdbc.type.ParserVersion;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class FireboltConnectionProviderTest {
+
+    @Mock
+    private FireboltConnectionProvider.FireboltConnectionProviderWrapper mockFireboltConnectionProviderWrapper;
+
+    @Mock
+    private FireboltConnectionUserPassword mockFireboltConnectionUserPassword;
+
+    @Mock
+    private FireboltConnectionServiceSecret mockFireboltConnectionServiceSecret;
+
+    @Mock
+    private LocalhostFireboltConnectionServiceSecret mockLocalhostFireboltConnectionServiceSecret;
+
+    private FireboltConnectionProvider fireboltConnectionProvider;
+
+    @BeforeEach
+    public void setupMethod() {
+        fireboltConnectionProvider = new FireboltConnectionProvider(mockFireboltConnectionProviderWrapper);
+    }
+
+    static Stream<Arguments> v1JdbcConnection() {
+        return Stream.of(
+                Arguments.of("jdbc:firebolt://api.app.firebolt.io", asProperties(Map.of("user", "myuser@email.com", "password", "value"))),
+                Arguments.of("jdbc:firebolt://api.app.firebolt.io/my_db", asProperties(Map.of("user", "myuser@email.com", "password", "value"))),
+                Arguments.of("jdbc:firebolt://api.app.firebolt.io/my_db?account=developer", asProperties(Map.of("user", "myuser@email.com", "password", "value", "account", "my_account")))
+        );
+    }
+    @ParameterizedTest
+    @MethodSource("v1JdbcConnection")
+    void canDetectV1Connection(String url, Properties connectionProperties) throws SQLException {
+        when(mockFireboltConnectionProviderWrapper.createFireboltConnectionUsernamePassword(url, connectionProperties, ParserVersion.LEGACY)).thenReturn(mockFireboltConnectionUserPassword);
+        FireboltConnection fireboltConnection = fireboltConnectionProvider.create(url, connectionProperties);
+
+        assertSame(mockFireboltConnectionUserPassword, fireboltConnection);
+
+        verify(mockFireboltConnectionProviderWrapper, never()).createLocalhostFireboltConnectionServiceSecret(anyString(), any(Properties.class), any(ParserVersion.class));
+        verify(mockFireboltConnectionProviderWrapper, never()).createFireboltConnectionServiceSecret(anyString(), any(Properties.class), any(ParserVersion.class));
+    }
+
+    @Test
+    void cannotCreateV1ConnectionWhenConnectingToBackendFails() throws SQLException {
+        String validJdbc1Url = "jdbc:firebolt://api.app.firebolt.io";
+        Properties validV1Properties = asProperties(Map.of("user", "myuser@email.com", "password", "value"));
+
+        when(mockFireboltConnectionProviderWrapper.createFireboltConnectionUsernamePassword(validJdbc1Url, validV1Properties, ParserVersion.LEGACY)).thenThrow(SQLException.class);
+        assertThrows(SQLException.class, () -> fireboltConnectionProvider.create(validJdbc1Url, validV1Properties));
+    }
+
+    static Stream<Arguments> v2JdbcConnection() {
+        return Stream.of(
+                Arguments.of("jdbc:firebolt:my_db", asProperties(Map.of("client_id", "my client", "client_secret", "my_secret"))),
+                Arguments.of("jdbc:firebolt:my_db?engine=my_engine", asProperties(Map.of("client_id", "my client", "client_secret", "my_secret")))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("v2JdbcConnection")
+    void canDetectV2Connection(String url, Properties connectionProperties) throws SQLException {
+        when(mockFireboltConnectionProviderWrapper.createFireboltConnectionServiceSecret(url, connectionProperties, ParserVersion.CURRENT)).thenReturn(mockFireboltConnectionServiceSecret);
+
+        FireboltConnection fireboltConnection = fireboltConnectionProvider.create(url, connectionProperties);
+        assertSame(mockFireboltConnectionServiceSecret, fireboltConnection);
+
+        verify(mockFireboltConnectionProviderWrapper, never()).createLocalhostFireboltConnectionServiceSecret(anyString(), any(Properties.class), any(ParserVersion.class));
+        verify(mockFireboltConnectionProviderWrapper, never()).createFireboltConnectionUsernamePassword(anyString(), any(Properties.class), any(ParserVersion.class));
+    }
+
+    @Test
+    void cannotCreateV2ConnectionWhenConnectingToBackendFails() throws SQLException {
+        String validJdbc2Url = "jdbc:firebolt:my_db";
+        Properties validV2Properties = asProperties(Map.of("client_id", "my client", "client_secret", "my_secret"));
+
+        when(mockFireboltConnectionProviderWrapper.createFireboltConnectionServiceSecret(validJdbc2Url, validV2Properties, ParserVersion.CURRENT)).thenThrow(SQLException.class);
+        assertThrows(SQLException.class, () -> fireboltConnectionProvider.create(validJdbc2Url, validV2Properties));
+    }
+
+    static Stream<Arguments> v2LocalhostJdbcConnection() {
+        return Stream.of(
+                Arguments.of("jdbc:firebolt:my_db", asProperties(Map.of("client_id", "my client", "client_secret", "my_secret","host", "localhost"))),
+                Arguments.of("jdbc:firebolt:my_db?engine=my_engine", asProperties(Map.of("client_id", "my_client", "client_secret", "my_secret","host", "localhost")))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("v2LocalhostJdbcConnection")
+    void canDetectLocalhostV2Connection(String url, Properties connectionProperties) throws SQLException {
+        when(mockFireboltConnectionProviderWrapper.createLocalhostFireboltConnectionServiceSecret(url, connectionProperties, ParserVersion.CURRENT)).thenReturn(mockLocalhostFireboltConnectionServiceSecret);
+        FireboltConnection fireboltConnection = fireboltConnectionProvider.create(url, connectionProperties);
+
+        assertSame(mockLocalhostFireboltConnectionServiceSecret, fireboltConnection);
+
+        verify(mockFireboltConnectionProviderWrapper, never()).createFireboltConnectionServiceSecret(anyString(), any(Properties.class), any(ParserVersion.class));
+        verify(mockFireboltConnectionProviderWrapper, never()).createFireboltConnectionUsernamePassword(anyString(), any(Properties.class), any(ParserVersion.class));
+    }
+
+    @Test
+    void cannotCreateV2LocalhostConnectionWhenConnectingToBackendFails() throws SQLException {
+        String validJdbc2LocalhostUrl = "jdbc:firebolt:my_db";
+        Properties validV2LocalhostProperties = asProperties(Map.of("client_id", "my client", "client_secret", "my_secret","host","localhost"));
+
+        when(mockFireboltConnectionProviderWrapper.createLocalhostFireboltConnectionServiceSecret(validJdbc2LocalhostUrl, validV2LocalhostProperties, ParserVersion.CURRENT)).thenThrow(SQLException.class);
+        assertThrows(SQLException.class, () -> fireboltConnectionProvider.create(validJdbc2LocalhostUrl, validV2LocalhostProperties));
+    }
+
+
+    private static Properties asProperties(Map<String, String> map) {
+        Properties properties = new Properties();
+
+        map.entrySet().stream().forEach(entry -> properties.setProperty(entry.getKey(), entry.getValue()));
+
+        return properties;
+    }
+
+
+}

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
@@ -14,7 +14,9 @@ import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mockito;
 
+import static com.firebolt.jdbc.connection.settings.FireboltSessionProperty.HOST;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toMap;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -103,6 +105,18 @@ class FireboltConnectionServiceSecretTest extends FireboltConnectionTest {
     void shouldNotFetchTokenNorEngineHostForLocalFirebolt() throws SQLException {
         super.shouldNotFetchTokenNorEngineHostForLocalFirebolt();
         verifyNoInteractions(fireboltEngineService);
+    }
+
+    @Test
+    void cannotConnectWhenBothClientIdAndSecretAndAccessTokenArePartOfTheConnectionString() {
+        Properties propsWithToken = new Properties();
+        propsWithToken.setProperty("client_id", "some clientid");
+        propsWithToken.setProperty("client_secret", "do_not_tell_anyone");
+        propsWithToken.setProperty(HOST.getKey(), "firebolt_stating_url");
+        propsWithToken.setProperty("access_token", "some token");
+        FireboltException exception = assertThrows(FireboltException.class, () -> createConnection(URL, propsWithToken));
+        assertEquals("Ambiguity: Both access token and client ID/secret are supplied", exception.getMessage());
+        Mockito.verifyNoMoreInteractions(fireboltAuthenticationService);
     }
 
     protected FireboltConnection createConnection(String url, Properties props) throws SQLException {

--- a/src/test/java/com/firebolt/jdbc/connection/LocalhostFireboltConnectionServiceTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/LocalhostFireboltConnectionServiceTest.java
@@ -1,0 +1,58 @@
+package com.firebolt.jdbc.connection;
+
+import com.firebolt.jdbc.service.FireboltAuthenticationService;
+import com.firebolt.jdbc.service.FireboltEngineInformationSchemaService;
+import com.firebolt.jdbc.service.FireboltGatewayUrlService;
+import com.firebolt.jdbc.service.FireboltStatementService;
+import com.firebolt.jdbc.type.ParserVersion;
+import java.sql.SQLException;
+import java.util.Properties;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.firebolt.jdbc.connection.settings.FireboltSessionProperty.ACCESS_TOKEN;
+import static com.firebolt.jdbc.connection.settings.FireboltSessionProperty.HOST;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class LocalhostFireboltConnectionServiceTest  {
+
+    private static final String URL = "jdbc:firebolt:db?env=dev&engine=eng&account=dev";
+
+    @Mock
+    protected FireboltAuthenticationService fireboltAuthenticationService;
+    @Mock
+    protected FireboltGatewayUrlService fireboltGatewayUrlService;
+
+    @Mock
+    protected FireboltEngineInformationSchemaService fireboltEngineService;
+    @Mock
+    protected FireboltStatementService fireboltStatementService;
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "localhost,access-token,access-token"})
+    void shouldGetConnectionTokenFromProperties(String host, String configuredAccessToken, String expectedAccessToken) throws SQLException {
+        Properties propsWithToken = new Properties();
+        if (host != null) {
+            propsWithToken.setProperty(HOST.getKey(), host);
+        }
+        if (configuredAccessToken != null) {
+            propsWithToken.setProperty(ACCESS_TOKEN.getKey(), configuredAccessToken);
+        }
+        try (FireboltConnection fireboltConnection = createConnection(URL, propsWithToken)) {
+            assertEquals(expectedAccessToken, fireboltConnection.getAccessToken().orElse(null));
+            Mockito.verifyNoMoreInteractions(fireboltAuthenticationService);
+        }
+    }
+
+    protected FireboltConnection createConnection(String url, Properties props) throws SQLException {
+        return new LocalhostFireboltConnectionServiceSecret(url, props, fireboltAuthenticationService, fireboltGatewayUrlService,
+                fireboltStatementService, fireboltEngineService, ParserVersion.CURRENT);
+
+    }
+}


### PR DESCRIPTION
Part2 - refactored the creating of a FireboltConnection. 
We will create 3 types of connections based on the url and the connection params:
 - FireboltConnectionUserPassword (existing)
 - FireboltConnectionServiceSecret (existing)
 - FireboltLocalhostConnectionServiceSecret (new) - for testing the case of localhost

This will give us a chance to validate parameters that we know are mandatory. For example for clientId/clientSecret connection we need to make sure the clientId, clientSecret, accountName exists (non-null values) since we will use that as a key for the connection cache