### PR TITLE
FIR-44620: add connection cache to url parameters

### DIFF
--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnection.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnection.java
@@ -160,17 +160,10 @@ public abstract class FireboltConnection extends JdbcBase implements Connection,
 	protected abstract void validateConnectionParameters() throws SQLException;
 
 	/**
-	 * By default, the connection caching is supported only on the clientId/clientSecret connections.
-	 * @return
+	 * If the connection information can be cached for subsequent reuse, then the specific connection should provide implementation
+	 * @return - true if the connection supports caching. False otherwise
 	 */
-	protected boolean isConnectionCachingEnabled() {
-		// check to see if the connection was set with a connection caching
-		if (loginProperties.isConnectionCachingEnabled()) {
-			log.warn("The cache_connection parameter is only supported with Firebolt 2.0. Your connections will not be cached");
-		}
-
-		return false;
-	}
+	protected abstract boolean isConnectionCachingEnabled();
 
 	public void removeExpiredTokens() throws SQLException {
 		fireboltAuthenticationService.removeConnectionTokens(httpConnectionUrl, loginProperties);

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnection.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnection.java
@@ -159,6 +159,19 @@ public abstract class FireboltConnection extends JdbcBase implements Connection,
 	 */
 	protected abstract void validateConnectionParameters() throws SQLException;
 
+	/**
+	 * By default, the connection caching is supported only on the clientId/clientSecret connections.
+	 * @return
+	 */
+	protected boolean isConnectionCachingEnabled() {
+		// check to see if the connection was set with a connection caching
+		if (loginProperties.isConnectionCachingEnabled()) {
+			log.warn("The cache_connection parameter is only supported with Firebolt 2.0. Your connections will not be cached");
+		}
+
+		return false;
+	}
+
 	public void removeExpiredTokens() throws SQLException {
 		fireboltAuthenticationService.removeConnectionTokens(httpConnectionUrl, loginProperties);
 	}

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecret.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecret.java
@@ -102,6 +102,11 @@ public class FireboltConnectionServiceSecret extends FireboltConnection {
 
     }
 
+    @Override
+    protected boolean isConnectionCachingEnabled() {
+        return Boolean.valueOf(loginProperties.isConnectionCachingEnabled());
+    }
+
     private FireboltProperties getSessionPropertiesForNonSystemEngine() throws SQLException {
         sessionProperties = sessionProperties.toBuilder().engine(loginProperties.getEngine()).build();
         Engine engine = getFireboltEngineService().getEngine(loginProperties);

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionUserPassword.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionUserPassword.java
@@ -86,6 +86,16 @@ public class FireboltConnectionUserPassword extends FireboltConnection {
     }
 
     @Override
+    protected boolean isConnectionCachingEnabled() {
+        // check to see if the connection was set with a connection caching
+        if (loginProperties.isConnectionCachingEnabled()) {
+            log.warn("The cache_connection parameter is only supported with Firebolt 2.0. Your connections will not be cached");
+        }
+
+        return false;
+    }
+
+    @Override
     protected FireboltProperties extractFireboltProperties(String jdbcUri, Properties connectionProperties) {
         FireboltProperties properties = super.extractFireboltProperties(jdbcUri, connectionProperties);
         boolean systemEngine = SYSTEM_ENGINE_NAME.equals(properties.getEngine());

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionUserPassword.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionUserPassword.java
@@ -15,10 +15,12 @@ import com.firebolt.jdbc.service.FireboltStatementService;
 import com.firebolt.jdbc.type.ParserVersion;
 import java.sql.SQLException;
 import java.util.Properties;
+import lombok.CustomLog;
 import lombok.NonNull;
 import okhttp3.OkHttpClient;
 import org.apache.commons.lang3.StringUtils;
 
+@CustomLog
 public class FireboltConnectionUserPassword extends FireboltConnection {
     // Visible for testing
     public static final String SYSTEM_ENGINE_NAME = "system";
@@ -75,6 +77,12 @@ public class FireboltConnectionUserPassword extends FireboltConnection {
         if (StringUtils.isNotBlank(accessToken)) {
             throw new FireboltException("Ambiguity: Both access token and client ID/secret are supplied");
         }
+
+        // check to see if the connection was set with a connection caching
+        if (loginProperties.isConnectionCachingEnabled()) {
+            log.warn("The cache_connection parameter is only supported with Firebolt 2.0. Your connections will not be cached");
+        }
+
     }
 
     @Override

--- a/src/main/java/com/firebolt/jdbc/connection/settings/FireboltProperties.java
+++ b/src/main/java/com/firebolt/jdbc/connection/settings/FireboltProperties.java
@@ -1,14 +1,5 @@
 package com.firebolt.jdbc.connection.settings;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.CustomLog;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.ToString;
-import org.jetbrains.annotations.NotNull;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -22,6 +13,14 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.CustomLog;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+import org.jetbrains.annotations.NotNull;
 
 import static com.firebolt.jdbc.connection.FireboltConnectionUserPassword.SYSTEM_ENGINE_NAME;
 import static com.firebolt.jdbc.util.PropertyUtil.mergeProperties;
@@ -77,6 +76,8 @@ public class FireboltProperties {
 	private final String accessToken;
 	private final boolean validateOnSystemEngine;
 	private final boolean mergePreparedStatementBatches;
+	private final boolean connectionCachingEnabled;
+
 	@Builder.Default
 	private Map<String, String> initialAdditionalProperties = new HashMap<>();
 	@Builder.Default
@@ -114,6 +115,7 @@ public class FireboltProperties {
 		userClients = getSetting(properties, FireboltSessionProperty.USER_CLIENTS);
 		validateOnSystemEngine = getSetting(properties, FireboltSessionProperty.VALIDATE_ON_SYSTEM_ENGINE);
 		mergePreparedStatementBatches = getSetting(properties, FireboltSessionProperty.MERGE_PREPARED_STATEMENT_BATCHES);
+		connectionCachingEnabled = getSetting(properties, FireboltSessionProperty.CACHE_CONNECTION);
 
 		environment = getEnvironment(configuredEnvironment, properties);
 		host = getHost(configuredEnvironment, properties);

--- a/src/main/java/com/firebolt/jdbc/connection/settings/FireboltSessionProperty.java
+++ b/src/main/java/com/firebolt/jdbc/connection/settings/FireboltSessionProperty.java
@@ -1,7 +1,5 @@
 package com.firebolt.jdbc.connection.settings;
 
-import lombok.Getter;
-
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
@@ -12,6 +10,7 @@ import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.Getter;
 
 import static java.lang.String.CASE_INSENSITIVE_ORDER;
 import static java.util.stream.Collectors.toMap;
@@ -72,6 +71,11 @@ public enum FireboltSessionProperty {
 			FireboltProperties::isValidateOnSystemEngine),
 	MERGE_PREPARED_STATEMENT_BATCHES("merge_prepared_statement_batches", false, Boolean.class,
 			"Whether to send prepared statement batches as a single statement. By default, they are sent one by one.", FireboltProperties::isMergePreparedStatementBatches),
+	/**
+	 * When the connection is cached the subsequent request to same url will reuse the same jwt token, system engine url and will not validate if engine and database exist if these were
+	 * validate already by the connection that was cached.
+	 */
+	CACHE_CONNECTION("cache_connection", true, Boolean.class, "Available only for Firebolt 2.0 connections. If true, the connection will be cached for 1 hour.", FireboltProperties::isConnectionCachingEnabled),
 	// We keep all the deprecated properties to ensure backward compatibility - but
 	// they do not have any effect.
 	@Deprecated

--- a/src/test/java/com/firebolt/jdbc/client/query/StatementClientImplTest.java
+++ b/src/test/java/com/firebolt/jdbc/client/query/StatementClientImplTest.java
@@ -424,6 +424,11 @@ class StatementClientImplTest {
 				// all params are valid
 			}
 
+			@Override
+			protected boolean isConnectionCachingEnabled() {
+				return false;
+			}
+
 		};
 		connection.createStatement().executeUpdate(useCommand);
 		return connection;

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionUserPasswordTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionUserPasswordTest.java
@@ -62,6 +62,25 @@ class FireboltConnectionUserPasswordTest extends FireboltConnectionTest {
         }
     }
 
+    @Test
+    void willDefaultToConnectionToNotBeCachedWhenNoConnectionParamIsPassedInUrl() throws SQLException {
+        try (FireboltConnection connection = createConnection(SYSTEM_ENGINE_URL, connectionProperties)) {
+            assertFalse(connection.isConnectionCachingEnabled());
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "true",
+            "false" })
+    void willNotRespectTheCacheConnectionParameterAndDefaultToAlwaysNotCacheTheConnection(String actualValue) throws SQLException {
+        // append to the system engine url the cache parameter
+        String urlWithCacheConnection = SYSTEM_ENGINE_URL + "&cache_connection=" + actualValue;
+        try (FireboltConnection connection = createConnection(urlWithCacheConnection, connectionProperties)) {
+            assertFalse(connection.isConnectionCachingEnabled());
+        }
+    }
+
     protected FireboltConnection createConnection(String url, Properties props) throws SQLException {
         return new FireboltConnectionUserPassword(url, props, fireboltAuthenticationService, fireboltStatementService,
                 fireboltEngineService, ParserVersion.LEGACY);

--- a/src/test/java/com/firebolt/jdbc/connection/LocalhostFireboltConnectionServiceTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/LocalhostFireboltConnectionServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static com.firebolt.jdbc.connection.settings.FireboltSessionProperty.ACCESS_TOKEN;
 import static com.firebolt.jdbc.connection.settings.FireboltSessionProperty.HOST;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -123,6 +124,25 @@ class LocalhostFireboltConnectionServiceTest  {
             verifyNoInteractions(fireboltAuthenticationService);
             verifyNoInteractions(fireboltGatewayUrlService);
             assertFalse(fireboltConnection.isClosed());
+        }
+    }
+
+    @Test
+    void localhostConnectionsAreCachedByDefault() throws SQLException {
+        try (FireboltConnection connection = createConnection(LOCAL_URL, connectionProperties)) {
+            assertTrue(connection.isConnectionCachingEnabled());
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "true,true",
+            "false,false" })
+    void canCacheConnectionsToLocalhost(String actualValue, boolean expectedValue) throws SQLException {
+        // append to the system engine url the cache parameter
+        String urlWithCacheConnection = LOCAL_URL + "&cache_connection=" + actualValue;
+        try (FireboltConnection connection = createConnection(urlWithCacheConnection, connectionProperties)) {
+            assertEquals(expectedValue, connection.isConnectionCachingEnabled());
         }
     }
 

--- a/src/test/java/com/firebolt/jdbc/connection/settings/FireboltPropertiesTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/settings/FireboltPropertiesTest.java
@@ -1,13 +1,12 @@
 package com.firebolt.jdbc.connection.settings;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -25,7 +24,7 @@ class FireboltPropertiesTest {
 				.principal(null).secret(null).host("host").ssl(true).initialAdditionalProperties(new HashMap<>())
 				.keepAliveTimeoutMillis(300000).maxConnectionsTotal(300).maxRetries(3)
 				.socketTimeoutMillis(0).connectionTimeoutMillis(60000).tcpKeepInterval(30).environment("app").tcpKeepIdle(60)
-				.tcpKeepCount(10).build();
+				.tcpKeepCount(10).connectionCachingEnabled(true).build();
 
 		Properties properties = new Properties();
 		properties.put("engine", "engine");
@@ -60,7 +59,7 @@ class FireboltPropertiesTest {
 				.initialAdditionalProperties(customProperties).keepAliveTimeoutMillis(300000)
 				.maxConnectionsTotal(300).maxRetries(3).socketTimeoutMillis(20).connectionTimeoutMillis(60000)
 				.tcpKeepInterval(30).tcpKeepIdle(60).tcpKeepCount(10).environment("app").validateOnSystemEngine(true)
-				.mergePreparedStatementBatches(true).build();
+				.mergePreparedStatementBatches(true).connectionCachingEnabled(true).build();
 		assertEquals(expectedDefaultProperties, new FireboltProperties(properties));
 	}
 


### PR DESCRIPTION
Add a new connection parameter: cache_connection

This will default to true for clientId/clientSecret connections (both for actual backend and when using localhost connections).

If the parameter is used on a username/password connection (Firebolt 1.0 backend) it will be ignored but a warning will be displayed to the user. 