### PR TITLE
feat: FIR-44260 add connection caching

### DIFF
--- a/src/main/java/com/firebolt/jdbc/cache/CacheService.java
+++ b/src/main/java/com/firebolt/jdbc/cache/CacheService.java
@@ -1,0 +1,32 @@
+package com.firebolt.jdbc.cache;
+
+import com.firebolt.jdbc.cache.exception.CacheException;
+import com.firebolt.jdbc.cache.key.CacheKey;
+import java.util.Optional;
+
+/**
+ * A cache service that will cache a connection object
+ */
+public interface CacheService {
+
+    /**
+     * Saves an entry in the cache. If there already is an entry for that key it will be overwritten
+     *
+     * @param key - the key associated with the value to be saved in the cache
+     * @param connectionCache - the value to be saved in the cache
+     *
+     * @throws CacheException - if there is a problem talking to the cache
+     */
+    void put(CacheKey key, ConnectionCache connectionCache) throws CacheException;
+
+    /**
+     * Returns the object from the cache. If the cache is not present then an empty value will be returned.
+     * If there is a problem accessing the cache a cacheException will be thrown
+     *
+     * @param key - the key for which the client is trying to retrive the associated saved value
+     * @return
+     * @throws CacheException - if there is a problem talking to the cache
+     */
+    Optional<ConnectionCache> get(CacheKey key) throws CacheException;
+
+}

--- a/src/main/java/com/firebolt/jdbc/cache/CacheServiceProvider.java
+++ b/src/main/java/com/firebolt/jdbc/cache/CacheServiceProvider.java
@@ -1,0 +1,37 @@
+package com.firebolt.jdbc.cache;
+
+/**
+ * Class responsible for creating the CacheService. We should only create one cache service per JVM, so singleton pattern is implemented
+ */
+@SuppressWarnings("java:S6548") // suppress the warning for singleton. Yes this is a singleton
+public class CacheServiceProvider {
+
+    private static CacheServiceProvider instance;
+
+    private CacheService inMemoryCacheService;
+    private CacheService onDiskCacheService;
+
+    // disable creation of the CacheServiceProvider using a constructor from outside this class
+    private CacheServiceProvider() {
+        this.inMemoryCacheService = new InMemoryCacheService();
+        this.onDiskCacheService = new OnDiskMemoryCacheService(inMemoryCacheService);
+    }
+
+    public static synchronized CacheServiceProvider getInstance() {
+        if (instance == null) {
+            instance = new CacheServiceProvider();
+        }
+
+        return instance;
+    }
+
+    public CacheService getCacheService(CacheType cacheType) throws IllegalArgumentException {
+        if (CacheType.IN_MEMORY == cacheType) {
+            return inMemoryCacheService;
+        } else if (CacheType.ON_DISK == cacheType) {
+            return onDiskCacheService;
+        }
+
+        throw new IllegalArgumentException("Unknown cache type: " + (cacheType == null ? "null" : cacheType.name()));
+    }
+}

--- a/src/main/java/com/firebolt/jdbc/cache/CacheType.java
+++ b/src/main/java/com/firebolt/jdbc/cache/CacheType.java
@@ -1,0 +1,14 @@
+package com.firebolt.jdbc.cache;
+
+public enum CacheType {
+
+    /**
+     * Will only keep the cached values in memory
+     */
+    IN_MEMORY,
+
+    /**
+     * Will keep the cached values in memory while also writing them to disk.
+     */
+    ON_DISK;
+}

--- a/src/main/java/com/firebolt/jdbc/cache/ConnectionCache.java
+++ b/src/main/java/com/firebolt/jdbc/cache/ConnectionCache.java
@@ -1,0 +1,57 @@
+package com.firebolt.jdbc.cache;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * This class encapsulates what information we cache for each connection
+ */
+public class ConnectionCache {
+
+    @Getter
+    private String connectionId;
+
+    @Setter
+    @Getter
+    private String accessToken;
+
+    @Setter
+    @Getter
+    private String systemEngineUrl;
+
+    /**
+     * On one connection cache we might store information about multiple databases
+     */
+    private Map<String, DatabaseOptions> databaseOptionsMap;
+
+    /**
+     * On one connection cache we might store information about multiple engines
+     */
+    private Map<String, EngineOptions> engineOptionsMap;
+
+    public ConnectionCache(String connectionId) {
+        this.connectionId = connectionId;
+        this.databaseOptionsMap = new ConcurrentHashMap<>();
+        this.engineOptionsMap = new ConcurrentHashMap<>();
+    }
+
+    public Optional<DatabaseOptions> getDatabaseOptions(String databaseName) {
+        return Optional.ofNullable(databaseOptionsMap.get(databaseName));
+    }
+
+    public void setDatabaseOptions(String databaseName, DatabaseOptions databaseOptions) {
+        databaseOptionsMap.put(databaseName, databaseOptions);
+    }
+
+    public Optional<EngineOptions> getEngineOptions(String engineName) {
+        return Optional.ofNullable(engineOptionsMap.get(engineName));
+    }
+
+    public void setEngineOptions(String engineName, EngineOptions engineOptions) {
+        engineOptionsMap.put(engineName, engineOptions);
+    }
+
+}

--- a/src/main/java/com/firebolt/jdbc/cache/DatabaseOptions.java
+++ b/src/main/java/com/firebolt/jdbc/cache/DatabaseOptions.java
@@ -1,0 +1,21 @@
+package com.firebolt.jdbc.cache;
+
+import java.util.List;
+import lombok.Getter;
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * Class that encapsulates all the parameters/options that we can cache for a particular database
+ */
+@Getter
+public class DatabaseOptions {
+
+    /**
+     * List of parameters. These parameters are parsed from the response header to a "USE database xxx" statement.
+     */
+    private List<Pair<String,String>> parameters;
+
+    public DatabaseOptions(List<Pair<String, String>> parameters) {
+        this.parameters = parameters;
+    }
+}

--- a/src/main/java/com/firebolt/jdbc/cache/EngineOptions.java
+++ b/src/main/java/com/firebolt/jdbc/cache/EngineOptions.java
@@ -1,0 +1,28 @@
+package com.firebolt.jdbc.cache;
+
+
+import java.util.List;
+import lombok.Getter;
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * Class that encapsulates all the parameters/options that we can cache for a particular engine
+ */
+@Getter
+public class EngineOptions {
+
+    /**
+     * This is the url of the engine. This is the url that should be used when sending queries to the engine name
+     */
+    private String engineUrl;
+
+    /**
+     * List of parameters. These parameters are parsed from the response header to a "USE engine xxx" statement.
+     */
+    private List<Pair<String,String>> parameters;
+
+    public EngineOptions(String engineUrl, List<Pair<String, String>> parameters) {
+        this.engineUrl = engineUrl;
+        this.parameters = parameters;
+    }
+}

--- a/src/main/java/com/firebolt/jdbc/cache/InMemoryCacheService.java
+++ b/src/main/java/com/firebolt/jdbc/cache/InMemoryCacheService.java
@@ -1,0 +1,40 @@
+package com.firebolt.jdbc.cache;
+
+import com.firebolt.jdbc.cache.exception.CacheException;
+import com.firebolt.jdbc.cache.key.CacheKey;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import net.jodah.expiringmap.ExpirationPolicy;
+import net.jodah.expiringmap.ExpiringMap;
+
+/**
+ * Cache service that uses the memory to store the cached values.
+ *
+ * NOTE: this should be package protected as the clients should use the {@link CacheServiceProvider} to create a cache service.
+ */
+class InMemoryCacheService implements CacheService {
+
+    // by default cache the connection for 1hr
+    private static final int DEFAULT_CACHE_TTL_IN_HOURS = 1;
+
+    private ExpiringMap<String, ConnectionCache> map;
+
+    public InMemoryCacheService() {
+        this(ExpiringMap.builder().variableExpiration().build());
+    }
+
+    // visible for testing
+    InMemoryCacheService(ExpiringMap<String, ConnectionCache> map) {
+        this.map = map;
+    }
+
+    @Override
+    public void put(CacheKey key, ConnectionCache connectionCache) throws CacheException {
+        map.put(key.getValue(), connectionCache, ExpirationPolicy.CREATED, DEFAULT_CACHE_TTL_IN_HOURS, TimeUnit.HOURS);
+    }
+
+    @Override
+    public Optional<ConnectionCache> get(CacheKey key) throws CacheException {
+        return Optional.ofNullable(map.get(key.getValue()));
+    }
+}

--- a/src/main/java/com/firebolt/jdbc/cache/OnDiskMemoryCacheService.java
+++ b/src/main/java/com/firebolt/jdbc/cache/OnDiskMemoryCacheService.java
@@ -1,0 +1,38 @@
+package com.firebolt.jdbc.cache;
+
+import com.firebolt.jdbc.cache.exception.CacheException;
+import com.firebolt.jdbc.cache.key.CacheKey;
+import java.util.Optional;
+
+/**
+ * A wrapper on another cache service, that will check the disk if the cached object is not present in the wrapped cached service
+ *
+ * Keep it package protected as only the CacheServiceProvider class should create it
+ */
+class OnDiskMemoryCacheService implements CacheService {
+
+    private CacheService cacheService;
+
+    public OnDiskMemoryCacheService(CacheService cacheService) {
+        this.cacheService = cacheService;
+    }
+
+
+    @Override
+    public void put(CacheKey key, ConnectionCache connectionCache) throws CacheException {
+        cacheService.put(key, connectionCache);
+
+        // also save to disk. to be implemented
+    }
+
+    @Override
+    public Optional<ConnectionCache> get(CacheKey key) throws CacheException {
+        // first check if it is in the memory cache
+        Optional<ConnectionCache> connectionCacheOptional = cacheService.get(key);
+        if (connectionCacheOptional.isPresent()) {
+            return connectionCacheOptional;
+        }
+        // to be implemented to get from disk
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/firebolt/jdbc/cache/exception/CacheException.java
+++ b/src/main/java/com/firebolt/jdbc/cache/exception/CacheException.java
@@ -1,0 +1,7 @@
+package com.firebolt.jdbc.cache.exception;
+
+/**
+ * Use this exception to signal that there was a problem talking to the actual cache.
+ */
+public class CacheException extends RuntimeException {
+}

--- a/src/main/java/com/firebolt/jdbc/cache/key/CacheKey.java
+++ b/src/main/java/com/firebolt/jdbc/cache/key/CacheKey.java
@@ -2,7 +2,7 @@ package com.firebolt.jdbc.cache.key;
 
 
 /**
- * Implementations should make sure that the CacheKey has equals and hash methods implemented
+ * The interface of a caching key.
  */
 public interface CacheKey {
 

--- a/src/main/java/com/firebolt/jdbc/cache/key/CacheKey.java
+++ b/src/main/java/com/firebolt/jdbc/cache/key/CacheKey.java
@@ -1,0 +1,14 @@
+package com.firebolt.jdbc.cache.key;
+
+
+/**
+ * Implementations should make sure that the CacheKey has equals and hash methods implemented
+ */
+public interface CacheKey {
+
+    /**
+     * Returns the cache key value
+     * @return
+     */
+    String getValue();
+}

--- a/src/main/java/com/firebolt/jdbc/cache/key/ClientSecretCacheKey.java
+++ b/src/main/java/com/firebolt/jdbc/cache/key/ClientSecretCacheKey.java
@@ -1,0 +1,24 @@
+package com.firebolt.jdbc.cache.key;
+
+import lombok.CustomLog;
+import lombok.EqualsAndHashCode;
+
+@CustomLog
+@EqualsAndHashCode
+public class ClientSecretCacheKey implements CacheKey {
+
+    private String value;
+
+    public ClientSecretCacheKey(String clientId, String clientSecret, String accountName) {
+        value = hashValues(clientId, clientSecret, accountName);
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    private String hashValues(String clientId, String clientSecret, String accountName) {
+        return String.join("#", clientId, clientSecret, accountName);
+    }
+}

--- a/src/main/java/com/firebolt/jdbc/cache/key/LocalhostCacheKey.java
+++ b/src/main/java/com/firebolt/jdbc/cache/key/LocalhostCacheKey.java
@@ -1,0 +1,26 @@
+package com.firebolt.jdbc.cache.key;
+
+import lombok.EqualsAndHashCode;
+
+/**
+ * When caching localhost connections, use the access token first 8 digits as the key
+ */
+@EqualsAndHashCode
+public class LocalhostCacheKey implements CacheKey {
+
+    private String value;
+
+    public LocalhostCacheKey(String accessToken) {
+        if (accessToken.length() > 8) {
+            this.value = accessToken.substring(0, 8);
+        } else {
+            // if access token is less than 8 chars, append 8 hashes and then just take the first 8 chars
+            value = new StringBuilder(accessToken).append("########").substring(0,8);
+        }
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionProvider.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionProvider.java
@@ -39,8 +39,8 @@ public class FireboltConnectionProvider {
                 return fireboltConnectionProviderWrapper.createFireboltConnectionUsernamePassword(url, connectionSettings, ParserVersion.LEGACY);
             case 2:
                 return isLocalhostConnection(url, connectionSettings) ?
-                        fireboltConnectionProviderWrapper.createLocalhostFireboltConnectionServiceSecret(url, connectionSettings, ParserVersion.CURRENT) :
-                        fireboltConnectionProviderWrapper.createFireboltConnectionServiceSecret(url, connectionSettings, ParserVersion.CURRENT);
+                        fireboltConnectionProviderWrapper.createLocalhostFireboltConnectionServiceSecret(url, connectionSettings) :
+                        fireboltConnectionProviderWrapper.createFireboltConnectionServiceSecret(url, connectionSettings);
             default: throw new IllegalArgumentException(format("Cannot distinguish version from url %s", url));
         }
     }
@@ -79,16 +79,16 @@ public class FireboltConnectionProvider {
             return new FireboltConnectionUserPassword(url, connectionSettings, parserVersion);
         }
 
-        public FireboltConnectionServiceSecret createFireboltConnectionServiceSecret(String url, Properties connectionSettings, ParserVersion parserVersion) throws SQLException {
+        public FireboltConnectionServiceSecret createFireboltConnectionServiceSecret(String url, Properties connectionSettings) throws SQLException {
             CacheServiceProvider cacheServiceProvider = CacheServiceProvider.getInstance();
             // the ON_DISK memory caching will be implemented after
-            return new FireboltConnectionServiceSecret(url, connectionSettings, parserVersion, cacheServiceProvider.getCacheService(CacheType.IN_MEMORY));
+            return new FireboltConnectionServiceSecret(url, connectionSettings, cacheServiceProvider.getCacheService(CacheType.IN_MEMORY));
         }
 
-        public LocalhostFireboltConnection createLocalhostFireboltConnectionServiceSecret(String url, Properties connectionSettings, ParserVersion parserVersion) throws SQLException {
+        public LocalhostFireboltConnection createLocalhostFireboltConnectionServiceSecret(String url, Properties connectionSettings) throws SQLException {
             CacheServiceProvider cacheServiceProvider = CacheServiceProvider.getInstance();
             // only in memory caching for localhost connections
-            return new LocalhostFireboltConnection(url, connectionSettings, parserVersion, cacheServiceProvider.getCacheService(CacheType.IN_MEMORY));
+            return new LocalhostFireboltConnection(url, connectionSettings, cacheServiceProvider.getCacheService(CacheType.IN_MEMORY));
         }
     }
 

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionProvider.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionProvider.java
@@ -1,6 +1,8 @@
 package com.firebolt.jdbc.connection;
 
 import com.firebolt.jdbc.annotation.ExcludeFromJacocoGeneratedReport;
+import com.firebolt.jdbc.cache.CacheServiceProvider;
+import com.firebolt.jdbc.cache.CacheType;
 import com.firebolt.jdbc.connection.settings.FireboltProperties;
 import com.firebolt.jdbc.type.ParserVersion;
 import com.firebolt.jdbc.util.PropertyUtil;
@@ -78,11 +80,15 @@ public class FireboltConnectionProvider {
         }
 
         public FireboltConnectionServiceSecret createFireboltConnectionServiceSecret(String url, Properties connectionSettings, ParserVersion parserVersion) throws SQLException {
-            return new FireboltConnectionServiceSecret(url, connectionSettings, parserVersion);
+            CacheServiceProvider cacheServiceProvider = CacheServiceProvider.getInstance();
+            // the ON_DISK memory caching will be implemented after
+            return new FireboltConnectionServiceSecret(url, connectionSettings, parserVersion, cacheServiceProvider.getCacheService(CacheType.IN_MEMORY));
         }
 
         public LocalhostFireboltConnection createLocalhostFireboltConnectionServiceSecret(String url, Properties connectionSettings, ParserVersion parserVersion) throws SQLException {
-            return new LocalhostFireboltConnection(url, connectionSettings, parserVersion);
+            CacheServiceProvider cacheServiceProvider = CacheServiceProvider.getInstance();
+            // only in memory caching for localhost connections
+            return new LocalhostFireboltConnection(url, connectionSettings, parserVersion, cacheServiceProvider.getCacheService(CacheType.IN_MEMORY));
         }
     }
 

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecret.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecret.java
@@ -1,6 +1,10 @@
 package com.firebolt.jdbc.connection;
 
 import com.firebolt.jdbc.annotation.ExcludeFromJacocoGeneratedReport;
+import com.firebolt.jdbc.cache.CacheService;
+import com.firebolt.jdbc.cache.ConnectionCache;
+import com.firebolt.jdbc.cache.key.CacheKey;
+import com.firebolt.jdbc.cache.key.ClientSecretCacheKey;
 import com.firebolt.jdbc.client.account.FireboltAccountRetriever;
 import com.firebolt.jdbc.client.authentication.AuthenticationRequest;
 import com.firebolt.jdbc.client.authentication.FireboltAuthenticationClient;
@@ -9,8 +13,6 @@ import com.firebolt.jdbc.client.gateway.GatewayUrlResponse;
 import com.firebolt.jdbc.connection.settings.FireboltProperties;
 import com.firebolt.jdbc.exception.FireboltException;
 import com.firebolt.jdbc.service.FireboltAuthenticationService;
-import com.firebolt.jdbc.service.FireboltEngineInformationSchemaService;
-import com.firebolt.jdbc.service.FireboltEngineService;
 import com.firebolt.jdbc.service.FireboltEngineVersion2Service;
 import com.firebolt.jdbc.service.FireboltGatewayUrlService;
 import com.firebolt.jdbc.service.FireboltStatementService;
@@ -19,39 +21,68 @@ import java.net.URL;
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Properties;
+import lombok.CustomLog;
 import lombok.NonNull;
 import okhttp3.OkHttpClient;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 
+@CustomLog
 public class FireboltConnectionServiceSecret extends FireboltConnection {
 
     private static final String PROTOCOL_VERSION = "2.1";
     private final FireboltGatewayUrlService fireboltGatewayUrlService;
-    private FireboltEngineService fireboltEngineService;
+    private FireboltEngineVersion2Service fireboltEngineVersion2Service;
 
+    private CacheService cacheService;
+
+    /**
+     * If caching is enabled, then this value will contain the cached values
+     */
+    private ConnectionCache connectionCache;
+
+    /**
+     * Each connection will have its unique id
+     */
+    private String connectionId;
+
+    @SuppressWarnings("java:S107") // ignore the too many params. Max is 7. Refactor this method at some point
     FireboltConnectionServiceSecret(@NonNull String url,
                                     Properties connectionSettings,
                                     FireboltAuthenticationService fireboltAuthenticationService,
                                     FireboltGatewayUrlService fireboltGatewayUrlService,
                                     FireboltStatementService fireboltStatementService,
-                                    FireboltEngineInformationSchemaService fireboltEngineService,
-                                    ParserVersion parserVersion) throws SQLException {
+                                    FireboltEngineVersion2Service fireboltEngineVersion2Service,
+                                    ParserVersion parserVersion,
+                                    CacheService cacheService) throws SQLException {
         super(url, connectionSettings, fireboltAuthenticationService, fireboltStatementService, PROTOCOL_VERSION,
                 parserVersion);
         this.fireboltGatewayUrlService = fireboltGatewayUrlService;
-        this.fireboltEngineService = fireboltEngineService;
+        this.fireboltEngineVersion2Service = fireboltEngineVersion2Service;
+        this.connectionId = generateUniqueConnectionId();
+        this.cacheService = cacheService;
         connect();
     }
 
     @ExcludeFromJacocoGeneratedReport
-    FireboltConnectionServiceSecret(@NonNull String url, Properties connectionSettings, ParserVersion parserVersion)
+    FireboltConnectionServiceSecret(@NonNull String url, Properties connectionSettings, ParserVersion parserVersion, CacheService cacheService)
             throws SQLException {
         super(url, connectionSettings, PROTOCOL_VERSION, parserVersion);
         OkHttpClient httpClient = getHttpClient(loginProperties);
         this.fireboltGatewayUrlService = new FireboltGatewayUrlService(createFireboltAccountRetriever(httpClient, GatewayUrlResponse.class));
-        this.fireboltEngineService = new FireboltEngineVersion2Service(this);
+        this.fireboltEngineVersion2Service = new FireboltEngineVersion2Service(this);
+        this.cacheService = cacheService;
+        this.connectionId = generateUniqueConnectionId();
         connect();
+    }
+
+    /**
+     * Generate a random 12 characters id
+     */
+    private String generateUniqueConnectionId() {
+        return RandomStringUtils.secure().nextAlphanumeric(12);
     }
 
     private <T> FireboltAccountRetriever<T> createFireboltAccountRetriever(OkHttpClient httpClient, Class<T> type) {
@@ -60,10 +91,69 @@ public class FireboltConnectionServiceSecret extends FireboltConnection {
 
     @Override
     protected void authenticate() throws SQLException {
-        String accessToken = getAccessToken(loginProperties).orElse("");
+        prepareCacheIfNeeded();
+
+        // make sure the clientId/clientSecret is valid
+        String accessToken = getAccessTokenInternal();
+
+        // make sure account exists
         sessionProperties = getSessionPropertiesForSystemEngine(accessToken, loginProperties.getAccount());
+
         if (!loginProperties.isSystemEngine()) {
-            sessionProperties = getSessionPropertiesForNonSystemEngine();
+            sessionProperties = getSessionPropertiesForNonSystemEngine(loginProperties.getEngine());
+        }
+    }
+
+    private String getAccessTokenInternal() throws SQLException {
+        if (!isConnectionCachingEnabled()) {
+            return getAccessToken(loginProperties).orElse("");
+        } else {
+            // caching is enabled so check the cache first
+            String accessTokenFromCache = connectionCache.getAccessToken();
+            if (StringUtils.isNotBlank(accessTokenFromCache)) {
+                return accessTokenFromCache;
+            }
+
+            // not in cache so get it from the source.
+            synchronized (connectionCache) {
+                String accessTokenFromFirebolt = getAccessToken(loginProperties).orElse("");
+
+                // only save it in cache if not empty
+                if (StringUtils.isNotBlank(accessTokenFromFirebolt)) {
+                    connectionCache.setAccessToken(accessTokenFromFirebolt);
+                }
+
+                return accessTokenFromFirebolt;
+            }
+        }
+    }
+
+    /**
+     * If there is no entry in the cache with this key, add one if caching is enabled
+     */
+    protected void prepareCacheIfNeeded() {
+        if (!isConnectionCachingEnabled()) {
+            return;
+        }
+
+        CacheKey key = getCacheKey();
+        Optional<ConnectionCache> connectionCacheOptional = cacheService.get(key);
+        if (connectionCacheOptional.isPresent()) {
+            this.connectionCache = connectionCacheOptional.get();
+            return;
+        }
+
+        synchronized (cacheService) {
+            // check again to make sure another thread did not already set the cache value
+            connectionCacheOptional = cacheService.get(key);
+            if (connectionCacheOptional.isPresent()) {
+                this.connectionCache = connectionCacheOptional.get();
+                return;
+            }
+
+            // no connection in cache so set a fresh connection
+            this.connectionCache = new ConnectionCache(connectionId);
+            cacheService.put(key, connectionCache);
         }
     }
 
@@ -96,7 +186,6 @@ public class FireboltConnectionServiceSecret extends FireboltConnection {
         if (StringUtils.isNotBlank(accessToken)) {
             throw new FireboltException("Ambiguity: Both access token and client ID/secret are supplied");
         }
-
     }
 
     @Override
@@ -104,9 +193,31 @@ public class FireboltConnectionServiceSecret extends FireboltConnection {
         return Boolean.valueOf(loginProperties.isConnectionCachingEnabled());
     }
 
-    private FireboltProperties getSessionPropertiesForNonSystemEngine() throws SQLException {
-        sessionProperties = sessionProperties.toBuilder().engine(loginProperties.getEngine()).build();
-        Engine engine = fireboltEngineService.getEngine(loginProperties);
+    protected CacheKey getCacheKey() {
+        // cache key is formed by clientId/clientSecret and account.
+        // When this method is called the connection parameters have already been validated syntactically
+        String clientId = loginProperties.getPrincipal();
+        String clientSecret = loginProperties.getSecret();
+        String account = loginProperties.getAccount();
+
+        return new ClientSecretCacheKey(clientId, clientSecret, account);
+    }
+
+    /**
+     * Verifies if the engine exists and sets its properties on the session properties. If the database is present, it will check if the database exists
+     * and also sets its properties on the session
+     * @param engineName
+     * @return
+     * @throws SQLException
+     */
+    private FireboltProperties getSessionPropertiesForNonSystemEngine(String engineName) throws SQLException {
+        // set the engine name on session properties
+        sessionProperties = sessionProperties.toBuilder().engine(engineName).build();
+
+        Optional<ConnectionCache> connectionCacheOptional = !isConnectionCachingEnabled() ? Optional.empty() : Optional.of(connectionCache);
+
+        Engine engine = fireboltEngineVersion2Service.getEngine(loginProperties, connectionCacheOptional);
+
         // update Firebolt properties. If we are here there are no contradictions between discovered and supplied parameters (db or engine): all validations are done in getEngine()
         return loginProperties.toBuilder()
                 .host(engine.getEndpoint()) // was not know until this point
@@ -118,10 +229,12 @@ public class FireboltConnectionServiceSecret extends FireboltConnection {
                 .build();
     }
 
+
     private FireboltProperties getSessionPropertiesForSystemEngine(String accessToken, String accountName) throws SQLException {
-        String systemEngineEndpoint = fireboltGatewayUrlService.getUrl(accessToken, accountName);
-        URL systemEngienUrl = UrlUtil.createUrl(systemEngineEndpoint);
-        Map<String, String> systemEngineUrlUrlParams = UrlUtil.getQueryParameters(systemEngienUrl);
+        String systemEngineEndpoint = getSystemEngineEndpointForAccount(accessToken, accountName);
+
+        URL systemEngineUrl = UrlUtil.createUrl(systemEngineEndpoint);
+        Map<String, String> systemEngineUrlUrlParams = UrlUtil.getQueryParameters(systemEngineUrl);
         for (Entry<String, String> e : systemEngineUrlUrlParams.entrySet()) {
             loginProperties.addProperty(e);
         }
@@ -129,8 +242,33 @@ public class FireboltConnectionServiceSecret extends FireboltConnection {
                 .toBuilder()
                 .systemEngine(true)
                 .compress(false)
-                .host(systemEngienUrl.getHost())
+                .host(systemEngineUrl.getHost())
                 .build();
+    }
+
+    private String getSystemEngineEndpointForAccount(String accessToken, String accountName) throws SQLException {
+        if (!isConnectionCachingEnabled()) {
+            return fireboltGatewayUrlService.getUrl(accessToken, accountName);
+        }
+
+        // caching is enabled so check the cache first
+        String systemEngineUrlFromCache = connectionCache.getSystemEngineUrl();
+        if (StringUtils.isNotBlank(systemEngineUrlFromCache)) {
+            return systemEngineUrlFromCache;
+        }
+
+        // not in cache so get it from the source.
+        synchronized (connectionCache) {
+            String systemEngineUrlFromFirebolt = fireboltGatewayUrlService.getUrl(accessToken, accountName);
+
+            // only save it in cache if not empty
+            if (StringUtils.isNotBlank(systemEngineUrlFromFirebolt)) {
+                connectionCache.setSystemEngineUrl(systemEngineUrlFromFirebolt);
+            }
+
+            return systemEngineUrlFromFirebolt;
+        }
+
     }
 
     @Override

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecret.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecret.java
@@ -36,7 +36,7 @@ public class FireboltConnectionServiceSecret extends FireboltConnection {
     private final FireboltGatewayUrlService fireboltGatewayUrlService;
     private FireboltEngineVersion2Service fireboltEngineVersion2Service;
 
-    private CacheService cacheService;
+    private final CacheService cacheService;
 
     /**
      * If caching is enabled, then this value will contain the cached values

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecret.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecret.java
@@ -48,17 +48,15 @@ public class FireboltConnectionServiceSecret extends FireboltConnection {
      */
     private String connectionId;
 
-    @SuppressWarnings("java:S107") // ignore the too many params. Max is 7. Refactor this method at some point
     FireboltConnectionServiceSecret(@NonNull String url,
                                     Properties connectionSettings,
                                     FireboltAuthenticationService fireboltAuthenticationService,
                                     FireboltGatewayUrlService fireboltGatewayUrlService,
                                     FireboltStatementService fireboltStatementService,
                                     FireboltEngineVersion2Service fireboltEngineVersion2Service,
-                                    ParserVersion parserVersion,
                                     CacheService cacheService) throws SQLException {
         super(url, connectionSettings, fireboltAuthenticationService, fireboltStatementService, PROTOCOL_VERSION,
-                parserVersion);
+                ParserVersion.CURRENT);
         this.fireboltGatewayUrlService = fireboltGatewayUrlService;
         this.fireboltEngineVersion2Service = fireboltEngineVersion2Service;
         this.connectionId = generateUniqueConnectionId();
@@ -67,9 +65,9 @@ public class FireboltConnectionServiceSecret extends FireboltConnection {
     }
 
     @ExcludeFromJacocoGeneratedReport
-    FireboltConnectionServiceSecret(@NonNull String url, Properties connectionSettings, ParserVersion parserVersion, CacheService cacheService)
+    FireboltConnectionServiceSecret(@NonNull String url, Properties connectionSettings, CacheService cacheService)
             throws SQLException {
-        super(url, connectionSettings, PROTOCOL_VERSION, parserVersion);
+        super(url, connectionSettings, PROTOCOL_VERSION, ParserVersion.CURRENT);
         OkHttpClient httpClient = getHttpClient(loginProperties);
         this.fireboltGatewayUrlService = new FireboltGatewayUrlService(createFireboltAccountRetriever(httpClient, GatewayUrlResponse.class));
         this.fireboltEngineVersion2Service = new FireboltEngineVersion2Service(this);

--- a/src/main/java/com/firebolt/jdbc/connection/LocalhostFireboltConnection.java
+++ b/src/main/java/com/firebolt/jdbc/connection/LocalhostFireboltConnection.java
@@ -1,10 +1,13 @@
 package com.firebolt.jdbc.connection;
 
 import com.firebolt.jdbc.annotation.ExcludeFromJacocoGeneratedReport;
+import com.firebolt.jdbc.cache.CacheService;
+import com.firebolt.jdbc.cache.key.CacheKey;
+import com.firebolt.jdbc.cache.key.LocalhostCacheKey;
 import com.firebolt.jdbc.connection.settings.FireboltProperties;
 import com.firebolt.jdbc.exception.FireboltException;
 import com.firebolt.jdbc.service.FireboltAuthenticationService;
-import com.firebolt.jdbc.service.FireboltEngineInformationSchemaService;
+import com.firebolt.jdbc.service.FireboltEngineVersion2Service;
 import com.firebolt.jdbc.service.FireboltGatewayUrlService;
 import com.firebolt.jdbc.service.FireboltStatementService;
 import com.firebolt.jdbc.type.ParserVersion;
@@ -20,8 +23,8 @@ import org.apache.commons.lang3.StringUtils;
 public class LocalhostFireboltConnection extends FireboltConnectionServiceSecret {
 
     @ExcludeFromJacocoGeneratedReport
-    LocalhostFireboltConnection(@NonNull String url, Properties connectionSettings, ParserVersion parserVersion) throws SQLException {
-        super(url, connectionSettings, parserVersion);
+    LocalhostFireboltConnection(@NonNull String url, Properties connectionSettings, ParserVersion parserVersion, CacheService cacheService) throws SQLException {
+        super(url, connectionSettings, parserVersion, cacheService);
     }
 
     // visible for testing
@@ -30,13 +33,16 @@ public class LocalhostFireboltConnection extends FireboltConnectionServiceSecret
                                 FireboltAuthenticationService fireboltAuthenticationService,
                                 FireboltGatewayUrlService fireboltGatewayUrlService,
                                 FireboltStatementService fireboltStatementService,
-                                FireboltEngineInformationSchemaService fireboltEngineService,
-                                ParserVersion parserVersion) throws SQLException {
-        super(url, connectionSettings, fireboltAuthenticationService, fireboltGatewayUrlService, fireboltStatementService, fireboltEngineService, parserVersion);
+                                FireboltEngineVersion2Service fireboltEngineVersion2Service,
+                                ParserVersion parserVersion,
+                                CacheService cacheService) throws SQLException {
+        super(url, connectionSettings, fireboltAuthenticationService, fireboltGatewayUrlService, fireboltStatementService, fireboltEngineVersion2Service, parserVersion, cacheService);
     }
 
     @Override
     protected void authenticate() throws SQLException {
+        super.prepareCacheIfNeeded();
+
         // When running packdb locally, the login properties are the session properties
         sessionProperties = loginProperties;
     }
@@ -69,6 +75,12 @@ public class LocalhostFireboltConnection extends FireboltConnectionServiceSecret
         if (StringUtils.isBlank(accessToken)) {
             throw new FireboltException("Cannot use localhost host connection without an access token");
         }
+    }
+
+    @Override
+    protected CacheKey getCacheKey() {
+        // when we get to this point we know that the access token is present in the login properties
+        return new LocalhostCacheKey(loginProperties.getAccessToken());
     }
 
 }

--- a/src/main/java/com/firebolt/jdbc/connection/LocalhostFireboltConnection.java
+++ b/src/main/java/com/firebolt/jdbc/connection/LocalhostFireboltConnection.java
@@ -10,7 +10,6 @@ import com.firebolt.jdbc.service.FireboltAuthenticationService;
 import com.firebolt.jdbc.service.FireboltEngineVersion2Service;
 import com.firebolt.jdbc.service.FireboltGatewayUrlService;
 import com.firebolt.jdbc.service.FireboltStatementService;
-import com.firebolt.jdbc.type.ParserVersion;
 import java.sql.SQLException;
 import java.util.Optional;
 import java.util.Properties;
@@ -23,8 +22,8 @@ import org.apache.commons.lang3.StringUtils;
 public class LocalhostFireboltConnection extends FireboltConnectionServiceSecret {
 
     @ExcludeFromJacocoGeneratedReport
-    LocalhostFireboltConnection(@NonNull String url, Properties connectionSettings, ParserVersion parserVersion, CacheService cacheService) throws SQLException {
-        super(url, connectionSettings, parserVersion, cacheService);
+    LocalhostFireboltConnection(@NonNull String url, Properties connectionSettings, CacheService cacheService) throws SQLException {
+        super(url, connectionSettings, cacheService);
     }
 
     // visible for testing
@@ -34,9 +33,8 @@ public class LocalhostFireboltConnection extends FireboltConnectionServiceSecret
                                 FireboltGatewayUrlService fireboltGatewayUrlService,
                                 FireboltStatementService fireboltStatementService,
                                 FireboltEngineVersion2Service fireboltEngineVersion2Service,
-                                ParserVersion parserVersion,
                                 CacheService cacheService) throws SQLException {
-        super(url, connectionSettings, fireboltAuthenticationService, fireboltGatewayUrlService, fireboltStatementService, fireboltEngineVersion2Service, parserVersion, cacheService);
+        super(url, connectionSettings, fireboltAuthenticationService, fireboltGatewayUrlService, fireboltStatementService, fireboltEngineVersion2Service, cacheService);
     }
 
     @Override

--- a/src/main/java/com/firebolt/jdbc/service/FireboltEngineVersion2Service.java
+++ b/src/main/java/com/firebolt/jdbc/service/FireboltEngineVersion2Service.java
@@ -1,56 +1,39 @@
 package com.firebolt.jdbc.service;
 
+import com.firebolt.jdbc.cache.ConnectionCache;
+import com.firebolt.jdbc.cache.DatabaseOptions;
+import com.firebolt.jdbc.cache.EngineOptions;
 import com.firebolt.jdbc.connection.Engine;
 import com.firebolt.jdbc.connection.FireboltConnection;
 import com.firebolt.jdbc.connection.settings.FireboltProperties;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import net.jodah.expiringmap.ExpiringMap;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import static java.lang.String.format;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 @Slf4j
-public class FireboltEngineVersion2Service implements FireboltEngineService {
-
-    // by default cache the values for 1hour
-    private static final long DEFAULT_CACHED_VERIFIED_DATABASES_IN_SECONDS = TimeUnit.HOURS.toSeconds(1);
-    private static final long DEFAULT_CACHED_VERIFIED_ENGINES_IN_SECONDS = TimeUnit.HOURS.toSeconds(1);
-
-    private static final ExpiringMap<String, List<Pair<String, String>>> CACHED_VERIFIED_DATABASES = ExpiringMap.builder()
-            .variableExpiration().build();
-    private static final ExpiringMap<String, List<Pair<String, String>>> CACHED_VERIFIED_ENGINES = ExpiringMap.builder()
-            .variableExpiration().build();
+public class FireboltEngineVersion2Service {
 
     private static final boolean DO_NOT_VALIDATE_CONNECTION_FLAG = false;
 
     private final FireboltConnection fireboltConnection;
-    private final long cacheDatabaseDurationInSeconds;
-    private final long cacheEngineDurationInSeconds;
 
     public FireboltEngineVersion2Service(FireboltConnection fireboltConnection) {
-        this(fireboltConnection, DEFAULT_CACHED_VERIFIED_DATABASES_IN_SECONDS, DEFAULT_CACHED_VERIFIED_ENGINES_IN_SECONDS);
-    }
-
-    // visible for testing
-    FireboltEngineVersion2Service(FireboltConnection fireboltConnection, long cachedDatabaseDuration, long cachedEngineDuration) {
         this.fireboltConnection = fireboltConnection;
-        this.cacheDatabaseDurationInSeconds = cachedDatabaseDuration;
-        this.cacheEngineDurationInSeconds = cachedEngineDuration;
     }
 
-    @Override
     @SuppressWarnings("java:S2077") // Formatting SQL queries is security-sensitive - looks safe in this case
-    public Engine getEngine(FireboltProperties properties) throws SQLException {
+    public Engine getEngine(FireboltProperties properties, Optional<ConnectionCache> connectionCacheOptional) throws SQLException {
         try (Statement statement = fireboltConnection.createStatement()) {
-            if (properties.getDatabase() != null) {
-                getAndSetDatabaseProperties(statement, properties.getHost(), properties.getDatabase());
+            if (StringUtils.isNotBlank(properties.getDatabase())) {
+                getAndSetDatabaseProperties(statement, properties.getDatabase(), connectionCacheOptional);
             }
-            getAndSetEngineProperties(statement, properties.getHost(), properties.getEngine());
+            getAndSetEngineProperties(statement, properties.getEngine(), connectionCacheOptional);
         }
         // now session properties are updated with new database and engine
         FireboltProperties sessionProperties = fireboltConnection.getSessionProperties();
@@ -63,30 +46,48 @@ public class FireboltEngineVersion2Service implements FireboltEngineService {
      * be caught while executing the statement, not during connection time.
      *
      * @param statement - statement that will execute the verification of the database
-     * @param host - the system engine url
      * @param databaseName - the name of the database to check
      */
-    private void getAndSetDatabaseProperties(Statement statement, String host, String databaseName) throws SQLException {
-        synchronized (CACHED_VERIFIED_DATABASES) {
+    private void getAndSetDatabaseProperties(Statement statement, String databaseName, Optional<ConnectionCache> connectionCacheOptional) throws SQLException {
+        // if the connection cache is empty it means it is not cachable
+        if (connectionCacheOptional.isEmpty()) {
+            // if no caching of the result then just make the call
+            statement.executeUpdate(use("DATABASE", databaseName));
+        } else {
+            // check the cache first
+            ConnectionCache connectionCache = connectionCacheOptional.get();
+            Optional<DatabaseOptions> databaseOptions = connectionCache.getDatabaseOptions(databaseName);
 
-            if (CACHED_VERIFIED_DATABASES.containsKey(asCacheKey(host, databaseName))) {
-                log.debug("Using cache verification of database");
-
-                // need to set the values on the connection that were cached on the original use database call
-                for (Pair<String, String> pair : CACHED_VERIFIED_DATABASES.get(asCacheKey(host, databaseName))) {
-                    fireboltConnection.addProperty(pair.getKey(), pair.getValue(), DO_NOT_VALIDATE_CONNECTION_FLAG);
-                }
-
+            if (databaseOptions.isPresent()) {
+                updateDatabasePropertiesOnConnection(databaseOptions.get());
                 return;
             }
 
-            statement.executeUpdate(use("DATABASE", databaseName));
+            synchronized (connectionCache) {
+                // make sure another thread did not already populate it
+                databaseOptions = connectionCache.getDatabaseOptions(databaseName);
+                if (databaseOptions.isPresent()) {
+                    updateDatabasePropertiesOnConnection(databaseOptions.get());
+                    return;
+                }
 
-            // as of Mar 2025 we know that as a side effect of calling "use database <xxx>" we are updating the database parameter on the connection.
-            // so if we want to use the value from cache we need to save this value on the connection when we use the cached connection
-            List<Pair<String, String>> cachedValuesForDatabase = List.of(
-                    Pair.of("database", fireboltConnection.getSessionProperties().getDatabase()));
-            CACHED_VERIFIED_DATABASES.put(asCacheKey(host, databaseName), cachedValuesForDatabase, cacheDatabaseDurationInSeconds, SECONDS);
+                // we know for sure it is not present, so execute the statement
+                statement.executeUpdate(use("DATABASE", databaseName));
+
+                // as of Mar 2025 we know that as a side effect of calling "use database <xxx>" we are updating the database parameter on the connection.
+                // so if we want to use the value from cache we need to save this value on the connection when we use the cached connection
+                List<Pair<String, String>> cachedValuesForDatabase = List.of(
+                        Pair.of("database", fireboltConnection.getSessionProperties().getDatabase()));
+                connectionCache.setDatabaseOptions(databaseName, new DatabaseOptions(cachedValuesForDatabase));
+            }
+        }
+    }
+
+    private void updateDatabasePropertiesOnConnection(DatabaseOptions databaseOptions) throws SQLException {
+        log.debug("Using cache verification of database");
+        // need to set the values on the connection that were cached on the original use database call
+        for (Pair<String, String> pair : databaseOptions.getParameters()) {
+            fireboltConnection.addProperty(pair.getKey(), pair.getValue(), DO_NOT_VALIDATE_CONNECTION_FLAG);
         }
     }
 
@@ -96,45 +97,60 @@ public class FireboltEngineVersion2Service implements FireboltEngineService {
      * be caught while executing the statement, not during connection time.
      *
      * @param statement - statement that will execute the verification of the database
-     * @param host - the system engine url
      * @param engineName - the name of the engine to check
 
      */
-    private void getAndSetEngineProperties(Statement statement, String host, String engineName) throws SQLException {
-        synchronized (CACHED_VERIFIED_ENGINES) {
-            if (CACHED_VERIFIED_ENGINES.containsKey(asCacheKey(host, engineName))) {
-                log.debug("Using cache verification of engine");
+    private void getAndSetEngineProperties(Statement statement, String engineName, Optional<ConnectionCache> connectionCacheOptional) throws SQLException {
+        // if the connection cache is empty it means it is not cachable
+        if (connectionCacheOptional.isEmpty()) {
+            // if no caching of the result then just make the call
+            statement.executeUpdate(use("ENGINE", engineName));
+        } else {
+            // check the cache first
+            // check the cache first
+            ConnectionCache connectionCache = connectionCacheOptional.get();
+            Optional<EngineOptions> engineOptions = connectionCache.getEngineOptions(engineName);
 
-                // need to set the values on the connection that were cached on the original use database call
-                for (Pair<String, String> pair : CACHED_VERIFIED_ENGINES.get(asCacheKey(host, engineName))) {
-                    if ("endpoint".equals(pair.getKey())) {
-                        fireboltConnection.setEndpoint(pair.getValue());
-                    } else {
-                        fireboltConnection.addProperty(pair.getKey(), pair.getValue(), DO_NOT_VALIDATE_CONNECTION_FLAG);
-                    }
-                }
-
+            if (engineOptions.isPresent()) {
+                updateEngineOptionsOnConnection(engineOptions.get());
                 return;
             }
 
-            statement.executeUpdate(use("ENGINE", engineName));
+            synchronized (connectionCache) {
+                // double check another thread did not already update the engine
+                engineOptions = connectionCache.getEngineOptions(engineName);
 
-            // as of Mar 2025 we know that the side effect of calling "use engine <xxx>" we are updating the endpoint and the engine parameter.
-            // so if we want to use the value from cache we need to save this value on the connection when we use the cached connection
-            List<Pair<String, String>> cachedValuesForEngine = List.of(
-                    Pair.of("engine", fireboltConnection.getSessionProperties().getEngine()),
-                    Pair.of("endpoint", fireboltConnection.getEndpoint()));
+                if (engineOptions.isPresent()) {
+                    updateEngineOptionsOnConnection(engineOptions.get());
+                    return;
+                }
 
-            CACHED_VERIFIED_ENGINES.put(asCacheKey(host, engineName), cachedValuesForEngine, cacheEngineDurationInSeconds, SECONDS);
+                // we know for sure it is not present, so execute the statement
+                statement.executeUpdate(use("ENGINE", engineName));
+
+                // as of Mar 2025 we know that the side effect of calling "use engine <xxx>" we are updating the endpoint and the engine parameter.
+                // so if we want to use the value from cache we need to save this value on the connection when we use the cached connection
+                List<Pair<String, String>> engineProperties = List.of(Pair.of("engine", fireboltConnection.getSessionProperties().getEngine()));
+                connectionCache.setEngineOptions(engineName, new EngineOptions(fireboltConnection.getEndpoint(), engineProperties));
+            }
         }
 
+    }
+
+    private void updateEngineOptionsOnConnection(EngineOptions engineOptions) throws SQLException {
+        log.debug("Using cache verification of engine");
+
+        // set the engine url
+        fireboltConnection.setEndpoint(engineOptions.getEngineUrl());
+
+        // need to set the values on the connection that were cached on the original use database call
+        for (Pair<String, String> pair : engineOptions.getParameters()) {
+            fireboltConnection.addProperty(pair.getKey(), pair.getValue(), DO_NOT_VALIDATE_CONNECTION_FLAG);
+        }
     }
 
     private String use(String entity, String name) {
         return format("USE %s \"%s\"", entity, name);
     }
 
-    private String asCacheKey(String host, String databaseName) {
-        return new StringBuilder(host).append(":").append(databaseName).toString();
-    }
 }

--- a/src/main/java/com/firebolt/jdbc/service/FireboltEngineVersion2Service.java
+++ b/src/main/java/com/firebolt/jdbc/service/FireboltEngineVersion2Service.java
@@ -48,7 +48,7 @@ public class FireboltEngineVersion2Service {
      * @param statement - statement that will execute the verification of the database
      * @param databaseName - the name of the database to check
      */
-    private void getAndSetDatabaseProperties(Statement statement, String databaseName, Optional<ConnectionCache> connectionCacheOptional) throws SQLException {
+    private void getAndSetDatabaseProperties(Statement statement, String databaseName, final Optional<ConnectionCache> connectionCacheOptional) throws SQLException {
         // if the connection cache is empty it means it is not cachable
         if (connectionCacheOptional.isEmpty()) {
             // if no caching of the result then just make the call
@@ -100,13 +100,12 @@ public class FireboltEngineVersion2Service {
      * @param engineName - the name of the engine to check
 
      */
-    private void getAndSetEngineProperties(Statement statement, String engineName, Optional<ConnectionCache> connectionCacheOptional) throws SQLException {
+    private void getAndSetEngineProperties(Statement statement, String engineName, final Optional<ConnectionCache> connectionCacheOptional) throws SQLException {
         // if the connection cache is empty it means it is not cachable
         if (connectionCacheOptional.isEmpty()) {
             // if no caching of the result then just make the call
             statement.executeUpdate(use("ENGINE", engineName));
         } else {
-            // check the cache first
             // check the cache first
             ConnectionCache connectionCache = connectionCacheOptional.get();
             Optional<EngineOptions> engineOptions = connectionCache.getEngineOptions(engineName);

--- a/src/test/java/com/firebolt/jdbc/cache/CacheServiceProviderTest.java
+++ b/src/test/java/com/firebolt/jdbc/cache/CacheServiceProviderTest.java
@@ -3,9 +3,9 @@ package com.firebolt.jdbc.cache;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CacheServiceProviderTest {
 
@@ -13,7 +13,7 @@ class CacheServiceProviderTest {
     void willReturnTheSameInstanceOfCacheProvider() {
         CacheServiceProvider cacheServiceProvider1 = CacheServiceProvider.getInstance();
         CacheServiceProvider cacheServiceProvider2 = CacheServiceProvider.getInstance();
-        assertSame(cacheServiceProvider1,cacheServiceProvider2);
+        assertSame(cacheServiceProvider1, cacheServiceProvider2);
     }
 
     @Test
@@ -22,7 +22,7 @@ class CacheServiceProviderTest {
         CacheService cacheService1 = cacheServiceProvider.getCacheService(CacheType.IN_MEMORY);
         CacheService cacheService2 = cacheServiceProvider.getCacheService(CacheType.IN_MEMORY);
         assertSame(cacheService1, cacheService2);
-        assertTrue(cacheService1 instanceof InMemoryCacheService);
+        assertInstanceOf(InMemoryCacheService.class, cacheService1);
     }
 
     @Test

--- a/src/test/java/com/firebolt/jdbc/cache/CacheServiceProviderTest.java
+++ b/src/test/java/com/firebolt/jdbc/cache/CacheServiceProviderTest.java
@@ -1,0 +1,33 @@
+package com.firebolt.jdbc.cache;
+
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+class CacheServiceProviderTest {
+
+    @Test
+    void willReturnTheSameInstanceOfCacheProvider() {
+        CacheServiceProvider cacheServiceProvider1 = CacheServiceProvider.getInstance();
+        CacheServiceProvider cacheServiceProvider2 = CacheServiceProvider.getInstance();
+        assertSame(cacheServiceProvider1,cacheServiceProvider2);
+    }
+
+    @Test
+    void willReturnTheSameCacheServiceEveryTime() {
+        CacheServiceProvider cacheServiceProvider = CacheServiceProvider.getInstance();
+        CacheService cacheService1 = cacheServiceProvider.getCacheService(CacheType.IN_MEMORY);
+        CacheService cacheService2 = cacheServiceProvider.getCacheService(CacheType.IN_MEMORY);
+        assertSame(cacheService1, cacheService2);
+        assertTrue(cacheService1 instanceof InMemoryCacheService);
+    }
+
+    @Test
+    void cannotCreateCacheServiceForNullCacheType() {
+        CacheServiceProvider cacheServiceProvider = CacheServiceProvider.getInstance();
+        assertThrows(IllegalArgumentException.class, () -> cacheServiceProvider.getCacheService(null));
+    }
+}

--- a/src/test/java/com/firebolt/jdbc/cache/InMemoryCacheServiceTest.java
+++ b/src/test/java/com/firebolt/jdbc/cache/InMemoryCacheServiceTest.java
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 class InMemoryCacheServiceTest {

--- a/src/test/java/com/firebolt/jdbc/cache/InMemoryCacheServiceTest.java
+++ b/src/test/java/com/firebolt/jdbc/cache/InMemoryCacheServiceTest.java
@@ -1,0 +1,59 @@
+package com.firebolt.jdbc.cache;
+
+import com.firebolt.jdbc.cache.key.CacheKey;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+class InMemoryCacheServiceTest {
+
+    private InMemoryCacheService inMemoryCacheService;
+
+    @Mock
+    private ConnectionCache mockConnectionCache;
+
+    @BeforeEach
+    void init() {
+        inMemoryCacheService = new InMemoryCacheService();
+    }
+
+    @Test
+    void willReturnEmptyIfKeyIsNotInCache() {
+        CacheKey cacheKey = new TestCacheKey("not_existing_key");
+        Optional<ConnectionCache> keyNotPresent = inMemoryCacheService.get(cacheKey);
+        assertTrue(keyNotPresent.isEmpty());
+    }
+
+    @Test
+    void canSaveCacheKeyAndGetIt() {
+        CacheKey cacheKey = new TestCacheKey("sampleKey");
+        Optional<ConnectionCache> connectionCacheOptional = inMemoryCacheService.get(cacheKey);
+        assertTrue(connectionCacheOptional.isEmpty());
+
+        inMemoryCacheService.put(cacheKey, mockConnectionCache);
+
+        connectionCacheOptional = inMemoryCacheService.get(cacheKey);
+        assertSame(connectionCacheOptional.get(), mockConnectionCache);
+    }
+
+    private class TestCacheKey implements CacheKey {
+
+        private String keyValue;
+
+        public TestCacheKey(String keyValue) {
+            this.keyValue = keyValue;
+        }
+
+        @Override
+        public String getValue() {
+            return keyValue;
+        }
+    }
+}

--- a/src/test/java/com/firebolt/jdbc/cache/InMemoryCacheServiceTest.java
+++ b/src/test/java/com/firebolt/jdbc/cache/InMemoryCacheServiceTest.java
@@ -47,7 +47,7 @@ class InMemoryCacheServiceTest {
     }
 
     @Test
-    @SuppressWarnings("java:S2925")
+    @SuppressWarnings("java:S2925") // need thread.sleep so we can wait for the cache entry to expire
     void willNotGetExpiredEntryFromCache() {
         ExpiringMap<String, ConnectionCache> expiringMap = ExpiringMap.builder().variableExpiration().build();
         CacheKey cacheKey = new TestCacheKey("key_to_expire");

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionProviderTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionProviderTest.java
@@ -59,8 +59,8 @@ class FireboltConnectionProviderTest {
 
         assertSame(mockFireboltConnectionUserPassword, fireboltConnection);
 
-        verify(mockFireboltConnectionProviderWrapper, never()).createLocalhostFireboltConnectionServiceSecret(anyString(), any(Properties.class), any(ParserVersion.class));
-        verify(mockFireboltConnectionProviderWrapper, never()).createFireboltConnectionServiceSecret(anyString(), any(Properties.class), any(ParserVersion.class));
+        verify(mockFireboltConnectionProviderWrapper, never()).createLocalhostFireboltConnectionServiceSecret(anyString(), any(Properties.class));
+        verify(mockFireboltConnectionProviderWrapper, never()).createFireboltConnectionServiceSecret(anyString(), any(Properties.class));
     }
 
     @Test
@@ -82,12 +82,12 @@ class FireboltConnectionProviderTest {
     @ParameterizedTest
     @MethodSource("v2JdbcConnection")
     void canDetectV2Connection(String url, Properties connectionProperties) throws SQLException {
-        when(mockFireboltConnectionProviderWrapper.createFireboltConnectionServiceSecret(url, connectionProperties, ParserVersion.CURRENT)).thenReturn(mockFireboltConnectionServiceSecret);
+        when(mockFireboltConnectionProviderWrapper.createFireboltConnectionServiceSecret(url, connectionProperties)).thenReturn(mockFireboltConnectionServiceSecret);
 
         FireboltConnection fireboltConnection = fireboltConnectionProvider.create(url, connectionProperties);
         assertSame(mockFireboltConnectionServiceSecret, fireboltConnection);
 
-        verify(mockFireboltConnectionProviderWrapper, never()).createLocalhostFireboltConnectionServiceSecret(anyString(), any(Properties.class), any(ParserVersion.class));
+        verify(mockFireboltConnectionProviderWrapper, never()).createLocalhostFireboltConnectionServiceSecret(anyString(), any(Properties.class));
         verify(mockFireboltConnectionProviderWrapper, never()).createFireboltConnectionUsernamePassword(anyString(), any(Properties.class), any(ParserVersion.class));
     }
 
@@ -96,7 +96,7 @@ class FireboltConnectionProviderTest {
         String validJdbc2Url = "jdbc:firebolt:my_db";
         Properties validV2Properties = asProperties(Map.of("client_id", "my client", "client_secret", "my_secret"));
 
-        when(mockFireboltConnectionProviderWrapper.createFireboltConnectionServiceSecret(validJdbc2Url, validV2Properties, ParserVersion.CURRENT)).thenThrow(SQLException.class);
+        when(mockFireboltConnectionProviderWrapper.createFireboltConnectionServiceSecret(validJdbc2Url, validV2Properties)).thenThrow(SQLException.class);
         assertThrows(SQLException.class, () -> fireboltConnectionProvider.create(validJdbc2Url, validV2Properties));
     }
 
@@ -110,12 +110,12 @@ class FireboltConnectionProviderTest {
     @ParameterizedTest
     @MethodSource("v2LocalhostJdbcConnection")
     void canDetectLocalhostV2Connection(String url, Properties connectionProperties) throws SQLException {
-        when(mockFireboltConnectionProviderWrapper.createLocalhostFireboltConnectionServiceSecret(url, connectionProperties, ParserVersion.CURRENT)).thenReturn(mockLocalhostFireboltConnection);
+        when(mockFireboltConnectionProviderWrapper.createLocalhostFireboltConnectionServiceSecret(url, connectionProperties)).thenReturn(mockLocalhostFireboltConnection);
         FireboltConnection fireboltConnection = fireboltConnectionProvider.create(url, connectionProperties);
 
         assertSame(mockLocalhostFireboltConnection, fireboltConnection);
 
-        verify(mockFireboltConnectionProviderWrapper, never()).createFireboltConnectionServiceSecret(anyString(), any(Properties.class), any(ParserVersion.class));
+        verify(mockFireboltConnectionProviderWrapper, never()).createFireboltConnectionServiceSecret(anyString(), any(Properties.class));
         verify(mockFireboltConnectionProviderWrapper, never()).createFireboltConnectionUsernamePassword(anyString(), any(Properties.class), any(ParserVersion.class));
     }
 
@@ -124,7 +124,7 @@ class FireboltConnectionProviderTest {
         String validJdbc2LocalhostUrl = "jdbc:firebolt:my_db";
         Properties validV2LocalhostProperties = asProperties(Map.of("client_id", "my client", "client_secret", "my_secret","host","localhost"));
 
-        when(mockFireboltConnectionProviderWrapper.createLocalhostFireboltConnectionServiceSecret(validJdbc2LocalhostUrl, validV2LocalhostProperties, ParserVersion.CURRENT)).thenThrow(SQLException.class);
+        when(mockFireboltConnectionProviderWrapper.createLocalhostFireboltConnectionServiceSecret(validJdbc2LocalhostUrl, validV2LocalhostProperties)).thenThrow(SQLException.class);
         assertThrows(SQLException.class, () -> fireboltConnectionProvider.create(validJdbc2LocalhostUrl, validV2LocalhostProperties));
     }
 

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -36,13 +37,13 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.toMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -281,7 +282,6 @@ class FireboltConnectionServiceSecretTest extends FireboltConnectionTest {
 
         // no cache is present for the key
         lenient().when(mockCacheService.get(cacheKey)).thenReturn(Optional.empty());
-        lenient().when(mockCacheService.get(cacheKey)).thenReturn(Optional.empty());
 
         lenient().doNothing().when(mockCacheService).put(eq(cacheKey), any(ConnectionCache.class));
 
@@ -293,7 +293,7 @@ class FireboltConnectionServiceSecretTest extends FireboltConnectionTest {
              assertEquals(cacheKey.getValue(), clientSecretCacheKey.getValue());
 
              ConnectionCache connectionCache = connectionCacheArgumentCaptor.getValue();
-             assertNotNull(connectionCache.getConnectionId());
+             Assertions.assertNotNull(connectionCache.getConnectionId());
              assertEquals(AN_ACCESS_TOKEN, connectionCache.getAccessToken());
              assertEquals(SYSTEM_ENGINE_URL_FOR_DEV_ACCOUNT, connectionCache.getSystemEngineUrl());
 
@@ -382,7 +382,7 @@ class FireboltConnectionServiceSecretTest extends FireboltConnectionTest {
         EngineOptions engineOptions = new EngineOptions(USER_ENGINE_ENDPOINT, List.of(Pair.of("engine", ENGINE_NAME)));
         connectionCache.setEngineOptions(ENGINE_NAME, engineOptions);
 
-        lenient().when(mockCacheService.get(cacheKey)).thenReturn(Optional.of(connectionCache));
+        when(mockCacheService.get(cacheKey)).thenReturn(Optional.of(connectionCache));
 
         // connection url with engine name
         try (FireboltConnection fireboltConnection = createConnection(CONNECTION_URL_WITH_ENGINE_AND_DB, connectionProperties)) {

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
@@ -1,20 +1,34 @@
 package com.firebolt.jdbc.connection;
 
+import com.firebolt.jdbc.cache.CacheService;
+import com.firebolt.jdbc.cache.ConnectionCache;
+import com.firebolt.jdbc.cache.DatabaseOptions;
+import com.firebolt.jdbc.cache.EngineOptions;
+import com.firebolt.jdbc.cache.key.CacheKey;
+import com.firebolt.jdbc.cache.key.ClientSecretCacheKey;
 import com.firebolt.jdbc.client.account.FireboltAccountRetriever;
 import com.firebolt.jdbc.client.gateway.GatewayUrlResponse;
 import com.firebolt.jdbc.connection.settings.FireboltProperties;
 import com.firebolt.jdbc.exception.FireboltException;
+import com.firebolt.jdbc.service.FireboltEngineVersion2Service;
 import com.firebolt.jdbc.service.FireboltGatewayUrlService;
 import com.firebolt.jdbc.statement.FireboltStatement;
 import com.firebolt.jdbc.type.ParserVersion;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import static com.firebolt.jdbc.connection.settings.FireboltSessionProperty.HOST;
@@ -22,6 +36,7 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.toMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -29,7 +44,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -38,9 +56,52 @@ import static org.mockito.Mockito.when;
 
 class FireboltConnectionServiceSecretTest extends FireboltConnectionTest {
     private static final String SYSTEM_ENGINE_URL = "jdbc:firebolt:db?env=dev&account=dev";
+    private static final String CONNECTION_URL_WITH_ENGINE_AND_DB = "jdbc:firebolt:db?env=dev&account=dev&engine=my_engine";
+
+    private static final String AN_ACCESS_TOKEN = "my access token";
+    private static final String ACCOUNT_NAME = "dev";
+
+    private static final String ENGINE_NAME = "my_engine";
+    private static final String DB_NAME = "db";
+
+    private static final String SYSTEM_ENGINE_URL_FOR_DEV_ACCOUNT = "https://someurl.com";
+
+    private static final String USER_ENGINE_ENDPOINT = "https://my_engine_endpoint.com";
+    private static final String A_CONNECTION_ID = "a_connection_id";
+
+    @Mock
+    private FireboltEngineVersion2Service fireboltEngineVersion2Service;
+    @Mock
+    private CacheService mockCacheService;
+
+    @Mock
+    private FireboltConnectionTokens mockFireboltConnectionTokens;
+
+    @Captor
+    private ArgumentCaptor<ConnectionCache> connectionCacheArgumentCaptor;
+    @Captor
+    private ArgumentCaptor<ClientSecretCacheKey> clientSecretCacheKeyArgumentCaptor;
+
+    private CacheKey cacheKey;
 
     public FireboltConnectionServiceSecretTest() {
         super("jdbc:firebolt:db?env=dev&engine=eng&account=dev");
+    }
+
+    @BeforeEach
+    void setupMethod() throws SQLException{
+        super.init();
+
+        Engine engine = new Engine(USER_ENGINE_ENDPOINT, "id123", ENGINE_NAME, DB_NAME, null);
+        lenient().when(fireboltEngineVersion2Service.getEngine(any(), any())).thenReturn(engine);
+
+        lenient().when(fireboltAuthenticationService.getConnectionTokens(eq("https://api.dev.firebolt.io:443"), any()))
+                .thenReturn(mockFireboltConnectionTokens);
+        lenient().when(mockFireboltConnectionTokens.getAccessToken()).thenReturn(AN_ACCESS_TOKEN);
+
+        lenient().when(fireboltGatewayUrlService.getUrl(AN_ACCESS_TOKEN, ACCOUNT_NAME)).thenReturn(SYSTEM_ENGINE_URL_FOR_DEV_ACCOUNT);
+
+        cacheKey = new ClientSecretCacheKey("somebody", "pa$$word", "dev");
     }
 
     @Test
@@ -89,8 +150,8 @@ class FireboltConnectionServiceSecretTest extends FireboltConnectionTest {
         when(fireboltGatewayUrlClient.retrieve(any(), any())).thenReturn(new GatewayUrlResponse(gatewayUrl));
         FireboltGatewayUrlService gatewayUrlService = new FireboltGatewayUrlService(fireboltGatewayUrlClient);
         FireboltConnection connection = new FireboltConnectionServiceSecret(SYSTEM_ENGINE_URL, connectionProperties,
-                fireboltAuthenticationService, gatewayUrlService, fireboltStatementService, fireboltEngineService,
-                ParserVersion.CURRENT);
+                fireboltAuthenticationService, gatewayUrlService, fireboltStatementService, fireboltEngineVersion2Service,
+                ParserVersion.CURRENT, mockCacheService);
         FireboltProperties sessionProperties  = connection.getSessionProperties();
         assertEquals(expectedHost, sessionProperties.getHost());
         assertEquals(expectedProps == null ? Map.of() : Arrays.stream(expectedProps.split(";")).map(kv -> kv.split("=")).collect(toMap(kv -> kv[0], kv -> kv[1])), sessionProperties.getAdditionalProperties());
@@ -204,8 +265,152 @@ class FireboltConnectionServiceSecretTest extends FireboltConnectionTest {
         }
     }
 
+    @Test
+    void shouldGetEngineUrlWhenEngineIsProvided() throws SQLException {
+        connectionProperties.put("engine", "engine");
+        when(fireboltEngineVersion2Service.getEngine(any(), any())).thenReturn(new Engine("http://my_endpoint", null, null, null, null));
+        try (FireboltConnection fireboltConnection = createConnection(url, connectionProperties)) {
+            verify(fireboltEngineVersion2Service).getEngine(argThat(props -> "engine".equals(props.getEngine()) && "db".equals(props.getDatabase())), any());
+            assertEquals("http://my_endpoint", fireboltConnection.getSessionProperties().getHost());
+        }
+    }
+
+    @Test
+    void canCacheJwtTokenAndSystemEngineWhenConnectionIsCachableAndNoUserEngineOrDatabaseIsSet() throws SQLException {
+        enableCacheConnection();
+
+        // no cache is present for the key
+        lenient().when(mockCacheService.get(cacheKey)).thenReturn(Optional.empty());
+        lenient().when(mockCacheService.get(cacheKey)).thenReturn(Optional.empty());
+
+        lenient().doNothing().when(mockCacheService).put(eq(cacheKey), any(ConnectionCache.class));
+
+        // system engine url does not have the database or the engine set
+        try (FireboltConnection fireboltConnection = createConnection(SYSTEM_ENGINE_URL, connectionProperties)) {
+             verify(mockCacheService).put(clientSecretCacheKeyArgumentCaptor.capture(), connectionCacheArgumentCaptor.capture());
+
+             ClientSecretCacheKey clientSecretCacheKey = clientSecretCacheKeyArgumentCaptor.getValue();
+             assertEquals(cacheKey.getValue(), clientSecretCacheKey.getValue());
+
+             ConnectionCache connectionCache = connectionCacheArgumentCaptor.getValue();
+             assertNotNull(connectionCache.getConnectionId());
+             assertEquals(AN_ACCESS_TOKEN, connectionCache.getAccessToken());
+             assertEquals(SYSTEM_ENGINE_URL_FOR_DEV_ACCOUNT, connectionCache.getSystemEngineUrl());
+
+             // should not try to get the user engine info
+             verify(fireboltEngineVersion2Service, never()).getEngine(any(), any());
+
+             FireboltProperties sessionProperties = fireboltConnection.getSessionProperties();
+             assertTrue(sessionProperties.isSystemEngine());
+             assertFalse(sessionProperties.isCompress());
+             assertEquals("someurl.com", sessionProperties.getHost());
+        }
+
+    }
+
+    @Test
+    void willGetJwtAndSystemEngineUrlFromCacheWhenConnectionCachingIsEnabledAndTheValuesAreInCache() throws SQLException {
+        enableCacheConnection();
+
+        // cache is present
+        ConnectionCache connectionCache = new ConnectionCache(A_CONNECTION_ID);
+        connectionCache.setAccessToken(AN_ACCESS_TOKEN);
+        connectionCache.setSystemEngineUrl(SYSTEM_ENGINE_URL_FOR_DEV_ACCOUNT);
+        lenient().when(mockCacheService.get(cacheKey)).thenReturn(Optional.of(connectionCache));
+
+        // system engine url does not have the database or the engine set
+        try (FireboltConnection fireboltConnection = createConnection(SYSTEM_ENGINE_URL, connectionProperties)) {
+            // no new cache object should be set
+            verify(mockCacheService, never()).put(any(CacheKey.class), any(ConnectionCache.class));
+
+            // no calls should be made to get the token or to the system engine
+            verify(fireboltAuthenticationService, never()).getConnectionTokens(anyString(), any(FireboltProperties.class));
+            verify(fireboltGatewayUrlService, never()).getUrl(any(), any());
+
+            // should not try to get the user engine info
+            verify(fireboltEngineVersion2Service, never()).getEngine(any(), any());
+
+            FireboltProperties sessionProperties = fireboltConnection.getSessionProperties();
+            assertTrue(sessionProperties.isSystemEngine());
+            assertFalse(sessionProperties.isCompress());
+            assertEquals("someurl.com", sessionProperties.getHost());
+        }
+    }
+
+    @Test
+    void canCacheJwtTokenSystemEngineDatabaseAndUserEngineWhenConnectionIsCachable() throws SQLException {
+        enableCacheConnection();
+
+        // no cache is present for the key
+        lenient().when(mockCacheService.get(cacheKey)).thenReturn(Optional.empty());
+        lenient().doNothing().when(mockCacheService).put(eq(cacheKey), any(ConnectionCache.class));
+
+        // connection url with engine name
+        try (FireboltConnection fireboltConnection = createConnection(CONNECTION_URL_WITH_ENGINE_AND_DB, connectionProperties)) {
+            verify(mockCacheService).put(clientSecretCacheKeyArgumentCaptor.capture(), connectionCacheArgumentCaptor.capture());
+
+            ClientSecretCacheKey clientSecretCacheKey = clientSecretCacheKeyArgumentCaptor.getValue();
+            assertEquals(cacheKey.getValue(), clientSecretCacheKey.getValue());
+
+            ConnectionCache connectionCache = connectionCacheArgumentCaptor.getValue();
+            assertNotNull(connectionCache.getConnectionId());
+            assertEquals(AN_ACCESS_TOKEN, connectionCache.getAccessToken());
+            assertEquals(SYSTEM_ENGINE_URL_FOR_DEV_ACCOUNT, connectionCache.getSystemEngineUrl());
+
+            // the engine options and db options are set as a side effect of this method so all we can check is make sure it is called
+            verify(fireboltEngineVersion2Service).getEngine(any(), any());
+
+            FireboltProperties sessionProperties = fireboltConnection.getSessionProperties();
+            assertFalse(sessionProperties.isSystemEngine());
+            assertTrue(sessionProperties.isCompress());
+            assertEquals("https://my_engine_endpoint.com", sessionProperties.getHost());
+            assertEquals(ENGINE_NAME, sessionProperties.getEngine());
+            assertEquals(DB_NAME, sessionProperties.getDatabase());
+        }
+
+    }
+
+    @Test
+    void willGetJwtSystemEngineUrlUserEngineEndpointAndDatabaseFromCacheWhenConnectionCachingIsEnabledAndTheValuesAreInCache() throws SQLException {
+        enableCacheConnection();
+
+        // cache is present
+        ConnectionCache connectionCache = new ConnectionCache(A_CONNECTION_ID);
+        connectionCache.setAccessToken(AN_ACCESS_TOKEN);
+        connectionCache.setSystemEngineUrl(SYSTEM_ENGINE_URL_FOR_DEV_ACCOUNT);
+        connectionCache.setDatabaseOptions(DB_NAME, new DatabaseOptions(List.of(Pair.of("database", DB_NAME))));
+        EngineOptions engineOptions = new EngineOptions(USER_ENGINE_ENDPOINT, List.of(Pair.of("engine", ENGINE_NAME)));
+        connectionCache.setEngineOptions(ENGINE_NAME, engineOptions);
+
+        lenient().when(mockCacheService.get(cacheKey)).thenReturn(Optional.of(connectionCache));
+
+        // connection url with engine name
+        try (FireboltConnection fireboltConnection = createConnection(CONNECTION_URL_WITH_ENGINE_AND_DB, connectionProperties)) {
+            // no new cache object should be set
+            verify(mockCacheService, never()).put(any(CacheKey.class), any(ConnectionCache.class));
+
+            // no calls should be made to get the token or to the system engine
+            verify(fireboltAuthenticationService, never()).getConnectionTokens(anyString(), any(FireboltProperties.class));
+            verify(fireboltGatewayUrlService, never()).getUrl(any(), any());
+
+            // the engine options and db options are set as a side effect of this method so all we can check is make sure it is called
+            verify(fireboltEngineVersion2Service).getEngine(any(), any());
+
+            FireboltProperties sessionProperties = fireboltConnection.getSessionProperties();
+            assertFalse(sessionProperties.isSystemEngine());
+            assertTrue(sessionProperties.isCompress());
+            assertEquals("https://my_engine_endpoint.com", sessionProperties.getHost());
+            assertEquals(ENGINE_NAME, sessionProperties.getEngine());
+            assertEquals(DB_NAME, sessionProperties.getDatabase());
+        }
+    }
+
+    private void enableCacheConnection() {
+        connectionProperties.put("cache_connection", "true");
+    }
+
     protected FireboltConnection createConnection(String url, Properties props) throws SQLException {
         return new FireboltConnectionServiceSecret(url, props, fireboltAuthenticationService, fireboltGatewayUrlService,
-                fireboltStatementService, fireboltEngineService, ParserVersion.CURRENT);
+                fireboltStatementService, fireboltEngineVersion2Service, ParserVersion.CURRENT, mockCacheService);
     }
 }

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
@@ -13,7 +13,6 @@ import com.firebolt.jdbc.exception.FireboltException;
 import com.firebolt.jdbc.service.FireboltEngineVersion2Service;
 import com.firebolt.jdbc.service.FireboltGatewayUrlService;
 import com.firebolt.jdbc.statement.FireboltStatement;
-import com.firebolt.jdbc.type.ParserVersion;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.util.Arrays;
@@ -152,7 +151,7 @@ class FireboltConnectionServiceSecretTest extends FireboltConnectionTest {
         FireboltGatewayUrlService gatewayUrlService = new FireboltGatewayUrlService(fireboltGatewayUrlClient);
         FireboltConnection connection = new FireboltConnectionServiceSecret(SYSTEM_ENGINE_URL, connectionProperties,
                 fireboltAuthenticationService, gatewayUrlService, fireboltStatementService, fireboltEngineVersion2Service,
-                ParserVersion.CURRENT, mockCacheService);
+                mockCacheService);
         FireboltProperties sessionProperties  = connection.getSessionProperties();
         assertEquals(expectedHost, sessionProperties.getHost());
         assertEquals(expectedProps == null ? Map.of() : Arrays.stream(expectedProps.split(";")).map(kv -> kv.split("=")).collect(toMap(kv -> kv[0], kv -> kv[1])), sessionProperties.getAdditionalProperties());
@@ -411,6 +410,6 @@ class FireboltConnectionServiceSecretTest extends FireboltConnectionTest {
 
     protected FireboltConnection createConnection(String url, Properties props) throws SQLException {
         return new FireboltConnectionServiceSecret(url, props, fireboltAuthenticationService, fireboltGatewayUrlService,
-                fireboltStatementService, fireboltEngineVersion2Service, ParserVersion.CURRENT, mockCacheService);
+                fireboltStatementService, fireboltEngineVersion2Service, mockCacheService);
     }
 }

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionTest.java
@@ -81,6 +81,10 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 abstract class FireboltConnectionTest {
 	private static final String SYSTEM_ENGINE_URL = "jdbc:firebolt:db?env=dev&account=dev";
+
+	private static final String ENGINE_NAME = "my_engine";
+	private static final String DB_NAME = "db";
+
 	private final FireboltConnectionTokens fireboltConnectionTokens = new FireboltConnectionTokens(null, 0);
 	@Captor
 	private ArgumentCaptor<FireboltProperties> propertiesArgumentCaptor;
@@ -146,7 +150,7 @@ abstract class FireboltConnectionTest {
 		lenient().when(fireboltAuthenticationService.getConnectionTokens(eq("https://api.dev.firebolt.io:443"), any()))
 				.thenReturn(fireboltConnectionTokens);
 		lenient().when(fireboltGatewayUrlService.getUrl(any(), any())).thenReturn("http://foo:8080/bar");
-		engine = new Engine("endpoint", "id123", "OK", "noname", null);
+		engine = new Engine("endpoint", "id123", ENGINE_NAME, DB_NAME, null);
 		lenient().when(fireboltEngineService.getEngine(any())).thenReturn(engine);
 		lenient().when(fireboltEngineService.doesDatabaseExist(any())).thenReturn(true);
 	}
@@ -588,7 +592,7 @@ abstract class FireboltConnectionTest {
 	void shouldGetDatabaseWhenGettingCatalog() throws SQLException {
 		connectionProperties.put("database", "db");
 		try (Connection fireboltConnection = createConnection(url, connectionProperties)) {
-			assertEquals("noname", fireboltConnection.getCatalog()); // retrieved engine's DB's name is "noname". Firebolt treats DB as catalog
+			assertEquals(DB_NAME, fireboltConnection.getCatalog()); // Firebolt treats DB as catalog
 		}
 	}
 
@@ -658,16 +662,6 @@ abstract class FireboltConnectionTest {
 	void shouldReturnEmptyResult(String name, Callable<?> function, Object expected) throws Exception {
 		connection = createConnection(url, connectionProperties);
 		assertEquals(expected, function.call());
-	}
-
-	@Test
-	void shouldGetEngineUrlWhenEngineIsProvided() throws SQLException {
-		connectionProperties.put("engine", "engine");
-		when(fireboltEngineService.getEngine(any())).thenReturn(new Engine("http://my_endpoint", null, null, null, null));
-		try (FireboltConnection fireboltConnection = createConnection(url, connectionProperties)) {
-			verify(fireboltEngineService).getEngine(argThat(props -> "engine".equals(props.getEngine()) && "db".equals(props.getDatabase())));
-			assertEquals("http://my_endpoint", fireboltConnection.getSessionProperties().getHost());
-		}
 	}
 
 	@Test

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionUserPasswordTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionUserPasswordTest.java
@@ -18,9 +18,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class FireboltConnectionUserPasswordTest extends FireboltConnectionTest {
     private static final String SYSTEM_ENGINE_URL = "jdbc:firebolt:db?env=dev&account=dev&engine=system";
@@ -93,6 +95,16 @@ class FireboltConnectionUserPasswordTest extends FireboltConnectionTest {
         String urlWithCacheConnection = SYSTEM_ENGINE_URL + "&cache_connection=" + actualValue;
         try (FireboltConnection connection = createConnection(urlWithCacheConnection, connectionProperties)) {
             assertFalse(connection.isConnectionCachingEnabled());
+        }
+    }
+
+    @Test
+    void shouldGetEngineUrlWhenEngineIsProvided() throws SQLException {
+        connectionProperties.put("engine", "engine");
+        when(fireboltEngineService.getEngine(any())).thenReturn(new Engine("http://my_endpoint", null, null, null, null));
+        try (FireboltConnection fireboltConnection = createConnection(url, connectionProperties)) {
+            verify(fireboltEngineService).getEngine(argThat(props -> "engine".equals(props.getEngine()) && "db".equals(props.getDatabase())));
+            assertEquals("http://my_endpoint", fireboltConnection.getSessionProperties().getHost());
         }
     }
 

--- a/src/test/java/com/firebolt/jdbc/connection/LocalhostFireboltConnectionTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/LocalhostFireboltConnectionTest.java
@@ -7,7 +7,6 @@ import com.firebolt.jdbc.service.FireboltAuthenticationService;
 import com.firebolt.jdbc.service.FireboltEngineVersion2Service;
 import com.firebolt.jdbc.service.FireboltGatewayUrlService;
 import com.firebolt.jdbc.service.FireboltStatementService;
-import com.firebolt.jdbc.type.ParserVersion;
 import java.sql.SQLException;
 import java.util.Properties;
 import org.junit.jupiter.api.BeforeEach;
@@ -163,7 +162,7 @@ class LocalhostFireboltConnectionTest {
 
     protected FireboltConnection createConnection(String url, Properties props) throws SQLException {
         return new LocalhostFireboltConnection(url, props, fireboltAuthenticationService, fireboltGatewayUrlService,
-                fireboltStatementService, fireboltEngineVersion2Service, ParserVersion.CURRENT, cacheService);
+                fireboltStatementService, fireboltEngineVersion2Service, cacheService);
 
     }
 }

--- a/src/test/java/com/firebolt/jdbc/connection/LocalhostFireboltConnectionTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/LocalhostFireboltConnectionTest.java
@@ -1,9 +1,10 @@
 package com.firebolt.jdbc.connection;
 
+import com.firebolt.jdbc.cache.CacheService;
 import com.firebolt.jdbc.connection.settings.FireboltProperties;
 import com.firebolt.jdbc.exception.FireboltException;
 import com.firebolt.jdbc.service.FireboltAuthenticationService;
-import com.firebolt.jdbc.service.FireboltEngineInformationSchemaService;
+import com.firebolt.jdbc.service.FireboltEngineVersion2Service;
 import com.firebolt.jdbc.service.FireboltGatewayUrlService;
 import com.firebolt.jdbc.service.FireboltStatementService;
 import com.firebolt.jdbc.type.ParserVersion;
@@ -36,14 +37,15 @@ class LocalhostFireboltConnectionTest {
     private static final String LOCAL_URL = "jdbc:firebolt:local_dev_db?account=dev&ssl=false&max_query_size=10000000&mask_internal_errors=0&host=localhost";
 
     @Mock
-    protected FireboltAuthenticationService fireboltAuthenticationService;
+    private FireboltAuthenticationService fireboltAuthenticationService;
     @Mock
-    protected FireboltGatewayUrlService fireboltGatewayUrlService;
-
+    private FireboltGatewayUrlService fireboltGatewayUrlService;
     @Mock
-    protected FireboltEngineInformationSchemaService fireboltEngineService;
+    private FireboltEngineVersion2Service fireboltEngineVersion2Service;
     @Mock
-    protected FireboltStatementService fireboltStatementService;
+    private FireboltStatementService fireboltStatementService;
+    @Mock
+    private CacheService cacheService;
 
     private Properties connectionProperties;
 
@@ -161,7 +163,7 @@ class LocalhostFireboltConnectionTest {
 
     protected FireboltConnection createConnection(String url, Properties props) throws SQLException {
         return new LocalhostFireboltConnection(url, props, fireboltAuthenticationService, fireboltGatewayUrlService,
-                fireboltStatementService, fireboltEngineService, ParserVersion.CURRENT);
+                fireboltStatementService, fireboltEngineVersion2Service, ParserVersion.CURRENT, cacheService);
 
     }
 }

--- a/src/test/java/com/firebolt/jdbc/service/FireboltEngineVersion2ServiceTest.java
+++ b/src/test/java/com/firebolt/jdbc/service/FireboltEngineVersion2ServiceTest.java
@@ -116,7 +116,6 @@ class FireboltEngineVersion2ServiceTest {
     @Test
     void canGetDatabaseAndEngineFromSourceWhenCachingIsEnabledButDatabaseNotInCache() throws SQLException {
         when(mockConnectionCache.getDatabaseOptions(MY_DATABASE)).thenReturn(Optional.empty());
-        when(mockConnectionCache.getDatabaseOptions(MY_DATABASE)).thenReturn(Optional.empty());
         when(mockConnectionCache.getEngineOptions(MY_ENGINE)).thenReturn(Optional.empty());
 
         doNothing().when(mockConnectionCache).setDatabaseOptions(eq(MY_DATABASE), any());

--- a/src/test/java/com/firebolt/jdbc/service/FireboltEngineVersion2ServiceTest.java
+++ b/src/test/java/com/firebolt/jdbc/service/FireboltEngineVersion2ServiceTest.java
@@ -1,40 +1,74 @@
 package com.firebolt.jdbc.service;
 
+import com.firebolt.jdbc.cache.ConnectionCache;
+import com.firebolt.jdbc.cache.DatabaseOptions;
+import com.firebolt.jdbc.cache.EngineOptions;
 import com.firebolt.jdbc.connection.Engine;
 import com.firebolt.jdbc.connection.FireboltConnection;
 import com.firebolt.jdbc.connection.settings.FireboltProperties;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class FireboltEngineVersion2ServiceTest {
 
-    private static final long ONE_SECOND = 1;
-
     private static final String MY_ENGINE = "my_engine";
-    private static final String YOUR_ENGINE = "your_engine";
 
     private static final String MY_DATABASE = "my_database";
-    private static final String YOUR_DATABASE = "your_database";
 
     private static final String MY_ENGINE_ENDPOINT = "api.region.firebolt.io";
-    private static final String YOUR_ENGINE_ENDPOINT = "api2.region.firebolt.io";
 
-    private static final String SYSTEM_ENGINE_URL = "system.engine.url";
+    @Mock
+    private ConnectionCache mockConnectionCache;
+    @Mock
+    private FireboltConnection mockFireboltConnection;
+    @Mock
+    private Statement mockFireboltStatement;
+
+    @Captor
+    private ArgumentCaptor<DatabaseOptions> databaseOptionsArgumentCaptor;
+    @Captor
+    private ArgumentCaptor<EngineOptions> engineOptionsArgumentCaptor;
+
+    private FireboltProperties properties;
+    private FireboltProperties sessionProperties;
+
+    @BeforeEach
+    void initMethod() {
+        Properties props = new Properties();
+        props.setProperty("database", MY_DATABASE);
+        props.setProperty("engine", MY_ENGINE);
+
+        properties = new FireboltProperties(props);
+
+        sessionProperties = new FireboltProperties(new Properties());
+        when(mockFireboltConnection.getSessionProperties()).thenReturn(sessionProperties);
+    }
 
     @ParameterizedTest(name = "database={0}")
     @ValueSource(strings = {MY_DATABASE})
@@ -45,210 +79,197 @@ class FireboltEngineVersion2ServiceTest {
             props.setProperty("database", database);
         }
         props.setProperty("engine", MY_ENGINE);
-        FireboltProperties properties = new FireboltProperties(props);
-        FireboltConnection connection = mock(FireboltConnection.class);
+        properties = new FireboltProperties(props);
         Statement statement = mock(Statement.class);
-        when(connection.createStatement()).thenReturn(statement);
+        when(mockFireboltConnection.createStatement()).thenReturn(statement);
         if (database != null) {
-            when(statement.executeUpdate("USE DATABASE " + database)).thenReturn(1);
+            when(statement.executeUpdate("USE DATABASE \"" + database + "\"")).thenReturn(1);
         } else {
-            verify(statement, never()).executeQuery("USE DATABASE " + database);
+            verify(statement, never()).executeQuery("USE DATABASE \"" + database + "\"");
         }
-        when(statement.executeUpdate("USE ENGINE " + MY_ENGINE)).thenReturn(1);
-        when(connection.getSessionProperties()).thenReturn(properties);
-        when(connection.getEndpoint()).thenReturn(MY_ENGINE_ENDPOINT);
+        when(statement.executeUpdate("USE ENGINE \"" + MY_ENGINE + "\"")).thenReturn(1);
+        when(mockFireboltConnection.getSessionProperties()).thenReturn(properties);
+        when(mockFireboltConnection.getEndpoint()).thenReturn(MY_ENGINE_ENDPOINT);
 
-        FireboltEngineVersion2Service  service = new FireboltEngineVersion2Service(connection);
-        Engine actualEngine = service.getEngine(properties);
+        FireboltEngineVersion2Service  service = new FireboltEngineVersion2Service(mockFireboltConnection);
+        Engine actualEngine = service.getEngine(properties, Optional.empty());
         assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, database, null), actualEngine);
     }
 
     @Test
-    void canGetDatabaseAndEngineFromCache() throws SQLException {
-        Properties props = new Properties();
-        props.setProperty("database", MY_DATABASE);
-        props.setProperty("engine", MY_ENGINE);
+    void canGetDatabaseAndEngineFromSourceWhenCachingIsNotEnabled() throws SQLException {
+        when(mockFireboltConnection.createStatement()).thenReturn(mockFireboltStatement);
+        when(mockFireboltStatement.executeUpdate("USE DATABASE \"" + MY_DATABASE + "\"")).thenReturn(1);
+        when(mockFireboltStatement.executeUpdate("USE ENGINE \"" + MY_ENGINE + "\"")).thenReturn(1);
+        when(mockFireboltConnection.getSessionProperties()).thenReturn(properties);
+        when(mockFireboltConnection.getEndpoint()).thenReturn(MY_ENGINE_ENDPOINT);
 
-        // we cache based on system engine url and the database/engine
-        String host = SYSTEM_ENGINE_URL + RandomStringUtils.secure().nextNumeric(5);
-        props.setProperty("host", host);
-
-        FireboltProperties properties = new FireboltProperties(props);
-
-        FireboltConnection firstConnection = mock(FireboltConnection.class);
-        Statement statementFromFirstConnection = mock(Statement.class);
-        when(firstConnection.createStatement()).thenReturn(statementFromFirstConnection);
-        when(statementFromFirstConnection.executeUpdate("USE DATABASE " + MY_DATABASE)).thenReturn(1);
-        when(statementFromFirstConnection.executeUpdate("USE ENGINE " + MY_ENGINE)).thenReturn(1);
-        when(firstConnection.getSessionProperties()).thenReturn(properties);
-        when(firstConnection.getEndpoint()).thenReturn(MY_ENGINE_ENDPOINT);
-
-        FireboltEngineVersion2Service service = new FireboltEngineVersion2Service(firstConnection);
-        Engine actualEngine = service.getEngine(properties);
-        assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, MY_DATABASE, null), actualEngine);
+        FireboltEngineVersion2Service service = new FireboltEngineVersion2Service(mockFireboltConnection);
+        Engine actualEngine = service.getEngine(properties, Optional.empty());
+        Assertions.assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, MY_DATABASE, null), actualEngine);
 
         // should make calls to the system engine url to check the database and engine
-        verify(statementFromFirstConnection).executeUpdate("USE DATABASE \"" + MY_DATABASE + "\"");
-        verify(statementFromFirstConnection).executeUpdate("USE ENGINE \"" + MY_ENGINE + "\"");
-
-        Properties secondProps = new Properties();
-        secondProps.setProperty("database", MY_DATABASE);
-        secondProps.setProperty("engine", MY_ENGINE);
-        secondProps.setProperty("host", host);
-
-        FireboltProperties secondConnectionProperties = new FireboltProperties(secondProps);
-
-        FireboltConnection secondConnection = mock(FireboltConnection.class);
-        when(secondConnection.getSessionProperties()).thenReturn(secondConnectionProperties);
-
-        Statement statementFromSecondConnection = mock(Statement.class);
-        when(secondConnection.createStatement()).thenReturn(statementFromSecondConnection);
-        when(secondConnection.getSessionProperties()).thenReturn(secondConnectionProperties);
-        when(secondConnection.getEndpoint()).thenReturn(MY_ENGINE_ENDPOINT);
-
-        doNothing().when(secondConnection).addProperty(anyString(), anyString());
-        doNothing().when(secondConnection).setEndpoint(anyString());
-
-        // on the second connection, it should use a cached engine
-        service = new FireboltEngineVersion2Service(secondConnection);
-        Engine actualEngineFromCache = service.getEngine(secondConnectionProperties);
-        assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, MY_DATABASE, null), actualEngineFromCache);
-
-        // should not execute any statements
-        verify(statementFromSecondConnection, never()).executeUpdate("USE DATABASE \"" + MY_DATABASE + "\"");
-        verify(statementFromSecondConnection, never()).executeUpdate("USE ENGINE \"" + MY_ENGINE + "\"");
-
-        // we should have the database and the engine set on the properties
-        assertEquals(MY_DATABASE, secondConnection.getSessionProperties().getDatabase());
-        assertEquals(MY_ENGINE, secondConnection.getSessionProperties().getEngine());
+        verify(mockFireboltStatement).executeUpdate("USE DATABASE \"" + MY_DATABASE + "\"");
+        verify(mockFireboltStatement).executeUpdate("USE ENGINE \"" + MY_ENGINE + "\"");
     }
 
     @Test
-    void canGetDatabaseAndEngineFromSourceWhenCacheExpired() throws SQLException {
-        Properties props = new Properties();
-        props.setProperty("database", MY_DATABASE);
-        props.setProperty("engine", MY_ENGINE);
+    void canGetDatabaseAndEngineFromSourceWhenCachingIsEnabledButDatabaseNotInCache() throws SQLException {
+        when(mockConnectionCache.getDatabaseOptions(MY_DATABASE)).thenReturn(Optional.empty());
+        when(mockConnectionCache.getDatabaseOptions(MY_DATABASE)).thenReturn(Optional.empty());
+        when(mockConnectionCache.getEngineOptions(MY_ENGINE)).thenReturn(Optional.empty());
 
-        // we cache based on system engine url and the database/engine
-        String host = SYSTEM_ENGINE_URL + RandomStringUtils.secure().nextNumeric(5);
-        props.setProperty("host", host);
+        doNothing().when(mockConnectionCache).setDatabaseOptions(eq(MY_DATABASE), any());
+        doNothing().when(mockConnectionCache).setEngineOptions(eq(MY_ENGINE), any());
 
-        FireboltProperties properties = new FireboltProperties(props);
+        // as a side effect of executing the "USE DATABASE xxx" the session properties will have the database name populated
+        sessionProperties.addProperty("database", MY_DATABASE);
+        sessionProperties.addProperty("engine", MY_ENGINE);
+        when(mockFireboltConnection.getEndpoint()).thenReturn(MY_ENGINE_ENDPOINT);
 
-        FireboltConnection firstConnection = mock(FireboltConnection.class);
-        Statement statementFromFirstConnection = mock(Statement.class);
-        when(firstConnection.createStatement()).thenReturn(statementFromFirstConnection);
-        when(statementFromFirstConnection.executeUpdate("USE DATABASE " + MY_DATABASE)).thenReturn(1);
-        when(statementFromFirstConnection.executeUpdate("USE ENGINE " + MY_ENGINE)).thenReturn(1);
-        when(firstConnection.getSessionProperties()).thenReturn(properties);
-        when(firstConnection.getEndpoint()).thenReturn(MY_ENGINE_ENDPOINT);
+        when(mockFireboltConnection.createStatement()).thenReturn(mockFireboltStatement);
+        when(mockFireboltStatement.executeUpdate("USE DATABASE \"" + MY_DATABASE + "\"")).thenReturn(1);
+        when(mockFireboltStatement.executeUpdate("USE ENGINE \"" + MY_ENGINE + "\"")).thenReturn(1);
 
-        // keep the values in cache for only 1 second
-        FireboltEngineVersion2Service service = new FireboltEngineVersion2Service(firstConnection, ONE_SECOND, ONE_SECOND);
-        Engine actualEngine = service.getEngine(properties);
-        assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, MY_DATABASE, null), actualEngine);
+        FireboltEngineVersion2Service service = new FireboltEngineVersion2Service(mockFireboltConnection);
+        Engine actualEngine = service.getEngine(properties, Optional.of(mockConnectionCache));
+        Assertions.assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, MY_DATABASE, null), actualEngine);
 
-        verify(statementFromFirstConnection).executeUpdate("USE DATABASE \"" + MY_DATABASE + "\"");
-        verify(statementFromFirstConnection).executeUpdate("USE ENGINE \"" + MY_ENGINE + "\"");
+        // should make calls to the system engine url to check the database and engine
+        verify(mockFireboltStatement).executeUpdate("USE DATABASE \"" + MY_DATABASE + "\"");
+        verify(mockFireboltStatement).executeUpdate("USE ENGINE \"" + MY_ENGINE + "\"");
 
-        // sleep for 2 seconds just to make sure the cache expired
-        sleepForMillis(TimeUnit.SECONDS.toMillis(2));
+        // should save the values in cache
+        verify(mockConnectionCache).setDatabaseOptions(eq(MY_DATABASE), databaseOptionsArgumentCaptor.capture());
+        DatabaseOptions savedDatabaseOptions = databaseOptionsArgumentCaptor.getValue();
+        List<Pair<String,String>> databaseParams = savedDatabaseOptions.getParameters();
+        assertEquals(1, databaseParams.size());
+        assertEquals("database", databaseParams.get(0).getKey());
+        assertEquals(MY_DATABASE, databaseParams.get(0).getValue());
 
-        Properties secondProps = new Properties();
-        secondProps.setProperty("database", MY_DATABASE);
-        secondProps.setProperty("engine", MY_ENGINE);
-        secondProps.setProperty("host", host);
-
-        FireboltProperties secondConnectionProperties = new FireboltProperties(secondProps);
-
-        FireboltConnection secondConnection = mock(FireboltConnection.class);
-        when(secondConnection.getSessionProperties()).thenReturn(secondConnectionProperties);
-
-        Statement statementFromSecondConnection = mock(Statement.class);
-        when(secondConnection.createStatement()).thenReturn(statementFromSecondConnection);
-        when(secondConnection.getSessionProperties()).thenReturn(secondConnectionProperties);
-        when(secondConnection.getEndpoint()).thenReturn(MY_ENGINE_ENDPOINT);
-        when(statementFromSecondConnection.executeUpdate("USE DATABASE " + MY_DATABASE)).thenReturn(1);
-        when(statementFromSecondConnection.executeUpdate("USE ENGINE " + MY_ENGINE)).thenReturn(1);
-
-        doNothing().when(secondConnection).addProperty(anyString(), anyString());
-        doNothing().when(secondConnection).setEndpoint(anyString());
-
-        // there should be no engine in cache so should call the backend to verify
-        service = new FireboltEngineVersion2Service(secondConnection);
-        Engine secondEngine = service.getEngine(secondConnectionProperties);
-        assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, MY_DATABASE, null), secondEngine);
-
-        // should execute the calls to verify the engine and database
-        verify(statementFromSecondConnection).executeUpdate("USE DATABASE \"" + MY_DATABASE + "\"");
-        verify(statementFromSecondConnection).executeUpdate("USE ENGINE \"" + MY_ENGINE + "\"");
-
-        // we should have the database and the engine set on the properties
-        assertEquals(MY_DATABASE, secondConnection.getSessionProperties().getDatabase());
-        assertEquals(MY_ENGINE, secondConnection.getSessionProperties().getEngine());
+        verify(mockConnectionCache).setEngineOptions(eq(MY_ENGINE), engineOptionsArgumentCaptor.capture());
+        EngineOptions engineOptions = engineOptionsArgumentCaptor.getValue();
+        assertEquals(MY_ENGINE_ENDPOINT, engineOptions.getEngineUrl());
+        assertEquals(1, engineOptions.getParameters().size());
+        assertEquals("engine", engineOptions.getParameters().get(0).getKey());
+        assertEquals(MY_ENGINE, engineOptions.getParameters().get(0).getValue());
     }
 
     @Test
-    void canGetDatabaseAndEngineFromSourceWhenDifferentDatabaseAndEngineAreCached() throws SQLException {
-        Properties props = new Properties();
-        props.setProperty("database", MY_DATABASE);
-        props.setProperty("engine", MY_ENGINE);
+    void canGetDatabaseAndEngineFromCache() throws SQLException {
+        when(mockFireboltConnection.createStatement()).thenReturn(mockFireboltStatement);
 
-        // we cache based on system engine url and the database/engine
-        String host = SYSTEM_ENGINE_URL + RandomStringUtils.secure().nextNumeric(5);
-        props.setProperty("host", host);
+        DatabaseOptions databaseOptions = new DatabaseOptions(List.of(Pair.of("database", MY_DATABASE)));
+        when(mockConnectionCache.getDatabaseOptions(MY_DATABASE)).thenReturn(Optional.of(databaseOptions));
 
-        FireboltProperties properties = new FireboltProperties(props);
+        EngineOptions engineOptions = new EngineOptions(MY_ENGINE_ENDPOINT, List.of(Pair.of("engine", MY_ENGINE)));
+        when(mockConnectionCache.getEngineOptions(MY_ENGINE)).thenReturn(Optional.of(engineOptions));
 
-        FireboltConnection firstConnection = mock(FireboltConnection.class);
-        Statement statementFromFirstConnection = mock(Statement.class);
-        when(firstConnection.createStatement()).thenReturn(statementFromFirstConnection);
-        when(statementFromFirstConnection.executeUpdate("USE DATABASE " + MY_DATABASE)).thenReturn(1);
-        when(statementFromFirstConnection.executeUpdate("USE ENGINE " + MY_ENGINE)).thenReturn(1);
-        when(firstConnection.getSessionProperties()).thenReturn(properties);
-        when(firstConnection.getEndpoint()).thenReturn(MY_ENGINE_ENDPOINT);
+        doNothing().when(mockFireboltConnection).addProperty(anyString(), anyString(), eq(false));
 
-        FireboltEngineVersion2Service service = new FireboltEngineVersion2Service(firstConnection);
-        Engine actualEngine = service.getEngine(properties);
+        sessionProperties.addProperty("database", MY_DATABASE);
+        sessionProperties.addProperty("engine", MY_ENGINE);
+        when(mockFireboltConnection.getEndpoint()).thenReturn(MY_ENGINE_ENDPOINT);
+
+        FireboltEngineVersion2Service service = new FireboltEngineVersion2Service(mockFireboltConnection);
+        Engine actualEngine = service.getEngine(properties, Optional.of(mockConnectionCache));
         assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, MY_DATABASE, null), actualEngine);
 
-        verify(statementFromFirstConnection).executeUpdate("USE DATABASE \"" + MY_DATABASE + "\"");
-        verify(statementFromFirstConnection).executeUpdate("USE ENGINE \"" + MY_ENGINE + "\"");
+        // should not make db calls
+        verify(mockFireboltStatement, never()).executeUpdate("USE DATABASE \"" + MY_DATABASE + "\"");
+        verify(mockFireboltStatement, never()).executeUpdate("USE ENGINE \"" + MY_ENGINE + "\"");
 
-        // use a different database and engine. Values should be obtained from the source
-        Properties secondProps = new Properties();
-        secondProps.setProperty("database", YOUR_DATABASE);
-        secondProps.setProperty("engine", YOUR_ENGINE);
-        secondProps.setProperty("host", host);
+        // should not update any values in cache
+        verify(mockConnectionCache, never()).setDatabaseOptions(any(), any());
+        verify(mockConnectionCache, never()).setEngineOptions(any(), any());
 
-        FireboltProperties secondConnectionProperties = new FireboltProperties(secondProps);
-
-        FireboltConnection secondConnection = mock(FireboltConnection.class);
-        when(secondConnection.getSessionProperties()).thenReturn(secondConnectionProperties);
-
-        Statement statementFromSecondConnection = mock(Statement.class);
-        when(secondConnection.createStatement()).thenReturn(statementFromSecondConnection);
-        when(secondConnection.getSessionProperties()).thenReturn(secondConnectionProperties);
-        when(secondConnection.getEndpoint()).thenReturn(YOUR_ENGINE_ENDPOINT);
-        when(statementFromSecondConnection.executeUpdate("USE DATABASE " + MY_DATABASE)).thenReturn(1);
-        when(statementFromSecondConnection.executeUpdate("USE ENGINE " + MY_ENGINE)).thenReturn(1);
-
-        service = new FireboltEngineVersion2Service(secondConnection);
-        Engine yourEngine = service.getEngine(secondConnectionProperties);
-        assertEquals(new Engine(YOUR_ENGINE_ENDPOINT, null, YOUR_ENGINE, YOUR_DATABASE, null), yourEngine);
-
-        verify(statementFromSecondConnection).executeUpdate("USE DATABASE \"" + YOUR_DATABASE + "\"");
-        verify(statementFromSecondConnection).executeUpdate("USE ENGINE \"" + YOUR_ENGINE + "\"");
+        // check that we should set the cached properties on the connection
+        verify(mockFireboltConnection).addProperty("database", MY_DATABASE, false);
+        verify(mockFireboltConnection).addProperty("engine", MY_ENGINE, false);
+        verify(mockFireboltConnection).setEndpoint(MY_ENGINE_ENDPOINT);
     }
 
-    @SuppressWarnings("java:S2925")
-    private void sleepForMillis(long millis) {
-        try {
-            Thread.sleep(millis);
-        } catch (InterruptedException e) {
-            // do nothing
-        }
+    @Test
+    void willOnlyGetDatabaseFromSourceIfEngineIsAlreadyCached() throws SQLException {
+        when(mockFireboltConnection.createStatement()).thenReturn(mockFireboltStatement);
+
+        // database not cached
+        when(mockConnectionCache.getDatabaseOptions(MY_DATABASE)).thenReturn(Optional.empty());
+
+        // but engine cached
+        EngineOptions engineOptions = new EngineOptions(MY_ENGINE_ENDPOINT, List.of(Pair.of("engine", MY_ENGINE)));
+        when(mockConnectionCache.getEngineOptions(MY_ENGINE)).thenReturn(Optional.of(engineOptions));
+
+        doNothing().when(mockFireboltConnection).addProperty(anyString(), anyString(), eq(false));
+
+        sessionProperties.addProperty("database", MY_DATABASE);
+        sessionProperties.addProperty("engine", MY_ENGINE);
+        when(mockFireboltConnection.getEndpoint()).thenReturn(MY_ENGINE_ENDPOINT);
+
+        FireboltEngineVersion2Service service = new FireboltEngineVersion2Service(mockFireboltConnection);
+        Engine actualEngine = service.getEngine(properties, Optional.of(mockConnectionCache));
+        assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, MY_DATABASE, null), actualEngine);
+
+        // should only make the call to get the database
+        verify(mockFireboltStatement).executeUpdate("USE DATABASE \"" + MY_DATABASE + "\"");
+        verify(mockFireboltStatement, never()).executeUpdate("USE ENGINE \"" + MY_ENGINE + "\"");
+
+        // should update the database options
+        verify(mockConnectionCache).setDatabaseOptions(eq(MY_DATABASE), databaseOptionsArgumentCaptor.capture());
+        verify(mockConnectionCache, never()).setEngineOptions(any(), any());
+
+        DatabaseOptions savedDatabaseOptions = databaseOptionsArgumentCaptor.getValue();
+        List<Pair<String,String>> databaseParams = savedDatabaseOptions.getParameters();
+        assertEquals(1, databaseParams.size());
+        assertEquals("database", databaseParams.get(0).getKey());
+        assertEquals(MY_DATABASE, databaseParams.get(0).getValue());
+
+        // check that we should set the cached properties on the connection for engine only
+        verify(mockFireboltConnection, never()).addProperty("database", MY_DATABASE, false);
+        verify(mockFireboltConnection).addProperty("engine", MY_ENGINE, false);
+        verify(mockFireboltConnection).setEndpoint(MY_ENGINE_ENDPOINT);
     }
 
+   @Test
+    void willOnlyGetEngineFromSourceIfDatabaseIsAlreadyCached() throws SQLException {
+        when(mockFireboltConnection.createStatement()).thenReturn(mockFireboltStatement);
+
+        // database cached
+       DatabaseOptions databaseOptions = new DatabaseOptions(List.of(Pair.of("database", MY_DATABASE)));
+       when(mockConnectionCache.getDatabaseOptions(MY_DATABASE)).thenReturn(Optional.of(databaseOptions));
+
+       // but engine not cached
+        when(mockConnectionCache.getEngineOptions(MY_ENGINE)).thenReturn(Optional.empty());
+
+        doNothing().when(mockFireboltConnection).addProperty(anyString(), anyString(), eq(false));
+
+        sessionProperties.addProperty("database", MY_DATABASE);
+        sessionProperties.addProperty("engine", MY_ENGINE);
+        when(mockFireboltConnection.getEndpoint()).thenReturn(MY_ENGINE_ENDPOINT);
+
+        FireboltEngineVersion2Service service = new FireboltEngineVersion2Service(mockFireboltConnection);
+        Engine actualEngine = service.getEngine(properties, Optional.of(mockConnectionCache));
+        assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, MY_DATABASE, null), actualEngine);
+
+        // should only make the call to get the engine
+        verify(mockFireboltStatement, never()).executeUpdate("USE DATABASE \"" + MY_DATABASE + "\"");
+        verify(mockFireboltStatement).executeUpdate("USE ENGINE \"" + MY_ENGINE + "\"");
+
+        // should update the engine options
+        verify(mockConnectionCache, never()).setDatabaseOptions(any(), any());
+        verify(mockConnectionCache).setEngineOptions(eq(MY_ENGINE), engineOptionsArgumentCaptor.capture());
+
+       verify(mockConnectionCache).setEngineOptions(eq(MY_ENGINE), engineOptionsArgumentCaptor.capture());
+       EngineOptions engineOptions = engineOptionsArgumentCaptor.getValue();
+       assertEquals(MY_ENGINE_ENDPOINT, engineOptions.getEngineUrl());
+       assertEquals(1, engineOptions.getParameters().size());
+       assertEquals("engine", engineOptions.getParameters().get(0).getKey());
+       assertEquals(MY_ENGINE, engineOptions.getParameters().get(0).getValue());
+
+       // check that we should set the cached properties on the connection for database only
+        verify(mockFireboltConnection).addProperty("database", MY_DATABASE, false);
+        verify(mockFireboltConnection, never()).addProperty("engine", MY_ENGINE, false);
+        verify(mockFireboltConnection, never()).setEndpoint(MY_ENGINE_ENDPOINT);
+    }
 
 }

--- a/src/test/java/com/firebolt/jdbc/service/FireboltEngineVersion2ServiceTest.java
+++ b/src/test/java/com/firebolt/jdbc/service/FireboltEngineVersion2ServiceTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,7 +23,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -106,7 +105,7 @@ class FireboltEngineVersion2ServiceTest {
 
         FireboltEngineVersion2Service service = new FireboltEngineVersion2Service(mockFireboltConnection);
         Engine actualEngine = service.getEngine(properties, Optional.empty());
-        Assertions.assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, MY_DATABASE, null), actualEngine);
+        assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, MY_DATABASE, null), actualEngine);
 
         // should make calls to the system engine url to check the database and engine
         verify(mockFireboltStatement).executeUpdate("USE DATABASE \"" + MY_DATABASE + "\"");
@@ -132,7 +131,7 @@ class FireboltEngineVersion2ServiceTest {
 
         FireboltEngineVersion2Service service = new FireboltEngineVersion2Service(mockFireboltConnection);
         Engine actualEngine = service.getEngine(properties, Optional.of(mockConnectionCache));
-        Assertions.assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, MY_DATABASE, null), actualEngine);
+        assertEquals(new Engine(MY_ENGINE_ENDPOINT, null, MY_ENGINE, MY_DATABASE, null), actualEngine);
 
         // should make calls to the system engine url to check the database and engine
         verify(mockFireboltStatement).executeUpdate("USE DATABASE \"" + MY_DATABASE + "\"");


### PR DESCRIPTION
Cache the connection (only the in memory caching is provided in the review). The on disk cache will be sent as a separate review. 

CacheService will be created by the CacheProvider which will be a static instance. This means it will have the same cacheService across multiple invocations (a.k.a - multiple connections creations).

ConnectionCache is the object that will the object that will be stored in cache. When this object is created the first time we will store the connectionId of the connection that created it and saved it in cache. 

DatabaseOptions is a container for saving the database information for a database name. Currently we only save the db name but if more info will be needed in the future will be adding to this object.

EngineOptions is a container for saving engine information for an engine name. We currently store just the engine endpoint and the name of the engine but if more info will be needed in the future will be adding to this object.

Additionally we will cache the access token and the system engine url. 

NOTE: 
1. We are still caching the token and the system engine url downstream but I will be removing this code in subsequent review. 
2. If this review is too big (and I know it is) I can try to break it up in smaller reviews but will need some more time. 

