### PR TITLE
feat: FIR-44260 add connection info to user agent header

### DIFF
--- a/src/integrationTest/java/integration/tests/client/UsageTrackingTest.java
+++ b/src/integrationTest/java/integration/tests/client/UsageTrackingTest.java
@@ -9,6 +9,7 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -17,16 +18,39 @@ public class UsageTrackingTest extends MockWebServerAwareIntegrationTest {
 	public void shouldSendRequestWithUserAgentHeaderContainingDriverAndClientInfo()
 			throws SQLException, InterruptedException {
 		mockBackEnd.enqueue(new MockResponse().setResponseCode(200));
+		mockBackEnd.enqueue(new MockResponse().setResponseCode(200));
+
 		try (FireboltConnection fireboltConnection = (FireboltConnection) createLocalConnection(String.format(
-				"?ssl=0&port=%d&max_retries=%d&user_drivers=AwesomeDriver:1.0.1&user_clients=GreatClient:0.1.4&access_token=my_token",
+				"?ssl=0&port=%d&max_retries=%d&user_drivers=AwesomeDriver:1.0.1&user_clients=GreatClient:0.1.4&access_token=token1",
 				mockBackEnd.getPort(), 3)); Statement statement = fireboltConnection.createStatement()) {
 			statement.execute("SELECT 1;");
 			RecordedRequest request = mockBackEnd.takeRequest();
 			String userAgentHeader = request.getHeaders().get("User-Agent");
 			assertNotNull(userAgentHeader);
 			assertTrue(userAgentHeader.startsWith("GreatClient/0.1.4" + " JDBC/" + VersionUtil.getDriverVersion()));
-			assertTrue(userAgentHeader.endsWith("AwesomeDriver/1.0.1"));
+			assertTrue(userAgentHeader.contains("AwesomeDriver/1.0.1"));
+
+			// connection is not cached so there should be only connId set
+			assertTrue(userAgentHeader.contains("connId"));
+			assertFalse(userAgentHeader.contains("cachedConnId"));
 		}
+
+		// create a second connection
+		try (FireboltConnection fireboltConnection = (FireboltConnection) createLocalConnection(String.format(
+				"?ssl=0&port=%d&max_retries=%d&user_drivers=AwesomeDriver:1.0.1&user_clients=GreatClient:0.1.4&access_token=token1",
+				mockBackEnd.getPort(), 3)); Statement statement = fireboltConnection.createStatement()) {
+			statement.execute("SELECT 1;");
+			RecordedRequest request = mockBackEnd.takeRequest();
+			String userAgentHeader = request.getHeaders().get("User-Agent");
+			assertNotNull(userAgentHeader);
+			assertTrue(userAgentHeader.startsWith("GreatClient/0.1.4" + " JDBC/" + VersionUtil.getDriverVersion()));
+			assertTrue(userAgentHeader.contains("AwesomeDriver/1.0.1"));
+
+			// connection should be cached
+			assertTrue(userAgentHeader.contains("connId"));
+			assertTrue(userAgentHeader.contains("cachedConnId"));
+		}
+
 	}
 
 }

--- a/src/main/java/com/firebolt/jdbc/cache/CacheServiceProvider.java
+++ b/src/main/java/com/firebolt/jdbc/cache/CacheServiceProvider.java
@@ -26,9 +26,9 @@ public class CacheServiceProvider {
     }
 
     public CacheService getCacheService(CacheType cacheType) throws IllegalArgumentException {
-        if (CacheType.IN_MEMORY == cacheType) {
+        if (CacheType.MEMORY == cacheType) {
             return inMemoryCacheService;
-        } else if (CacheType.ON_DISK == cacheType) {
+        } else if (CacheType.DISK == cacheType) {
             return onDiskCacheService;
         }
 

--- a/src/main/java/com/firebolt/jdbc/cache/CacheType.java
+++ b/src/main/java/com/firebolt/jdbc/cache/CacheType.java
@@ -5,10 +5,10 @@ public enum CacheType {
     /**
      * Will only keep the cached values in memory
      */
-    IN_MEMORY,
+    MEMORY,
 
     /**
      * Will keep the cached values in memory while also writing them to disk.
      */
-    ON_DISK;
+    DISK;
 }

--- a/src/main/java/com/firebolt/jdbc/cache/ConnectionCache.java
+++ b/src/main/java/com/firebolt/jdbc/cache/ConnectionCache.java
@@ -23,6 +23,13 @@ public class ConnectionCache {
     private String systemEngineUrl;
 
     /**
+     * Will have as source either Memory or Disk, if the cache was retrieved from memory or disk
+     */
+    @Getter
+    @Setter
+    String cacheSource;
+
+    /**
      * On one connection cache we might store information about multiple databases
      */
     private Map<String, DatabaseOptions> databaseOptionsMap;

--- a/src/main/java/com/firebolt/jdbc/cache/InMemoryCacheService.java
+++ b/src/main/java/com/firebolt/jdbc/cache/InMemoryCacheService.java
@@ -30,6 +30,8 @@ class InMemoryCacheService implements CacheService {
 
     @Override
     public void put(CacheKey key, ConnectionCache connectionCache) throws CacheException {
+        // set the source as memory
+        connectionCache.setCacheSource("Memory");
         map.put(key.getValue(), connectionCache, ExpirationPolicy.CREATED, DEFAULT_CACHE_TTL_IN_HOURS, TimeUnit.HOURS);
     }
 

--- a/src/main/java/com/firebolt/jdbc/client/FireboltClient.java
+++ b/src/main/java/com/firebolt/jdbc/client/FireboltClient.java
@@ -8,18 +8,6 @@ import com.firebolt.jdbc.exception.ServerError;
 import com.firebolt.jdbc.exception.ServerError.Error.Location;
 import com.firebolt.jdbc.resultset.compress.LZ4InputStream;
 import com.firebolt.jdbc.util.CloseableUtil;
-import lombok.CustomLog;
-import lombok.Getter;
-import lombok.NonNull;
-import okhttp3.Call;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -36,11 +24,20 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import lombok.CustomLog;
+import lombok.Getter;
+import lombok.NonNull;
+import okhttp3.Call;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import static java.lang.String.format;
 import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
@@ -250,10 +247,16 @@ public abstract class FireboltClient implements CacheListener {
 
 	private List<Entry<String, String>> createHeaders(String accessToken) {
 		List<Entry<String, String>> headers = new ArrayList<>();
-		headers.add(Map.entry(HEADER_USER_AGENT, getHeaderUserAgentValue()));
+		headers.add(Map.entry(HEADER_USER_AGENT, createUserAgentHeader()));
 		ofNullable(connection.getProtocolVersion()).ifPresent(version -> headers.add(Map.entry(HEADER_PROTOCOL_VERSION, version)));
 		ofNullable(accessToken).ifPresent(token -> headers.add(Map.entry(HEADER_AUTHORIZATION, HEADER_AUTHORIZATION_BEARER_PREFIX_VALUE + accessToken)));
 		return headers;
+	}
+
+	private String createUserAgentHeader() {
+		// add the user agent information from the connection
+		Optional<String> connectionUserAgentInfo = connection.getConnectionUserAgentHeader();
+		return connectionUserAgentInfo.isEmpty() ? headerUserAgentValue : new StringBuilder(headerUserAgentValue).append(";").append(connectionUserAgentInfo.get()).toString();
 	}
 
 	private String getInternalErrorWithHeadersText(Response response) {

--- a/src/main/java/com/firebolt/jdbc/connection/ConnectionIdGenerator.java
+++ b/src/main/java/com/firebolt/jdbc/connection/ConnectionIdGenerator.java
@@ -1,0 +1,27 @@
+package com.firebolt.jdbc.connection;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+/**
+ * Generates a new id for each connection. It will be a singleton since we only need one instance for all the connections.
+ */
+@SuppressWarnings("java:S6548") // suppress the warning for singleton. Yes this is a singleton
+public class ConnectionIdGenerator {
+
+    private static ConnectionIdGenerator instance;
+
+    public static synchronized ConnectionIdGenerator getInstance() {
+        if (instance == null) {
+            instance = new ConnectionIdGenerator();
+        }
+        return instance;
+    }
+
+    /**
+     * Will generate a new id. Randomly generate twelve chars (numbers and letters) string as a connection id
+     * @return
+     */
+    public String generateId() {
+        return RandomStringUtils.secure().nextAlphanumeric(12);
+    }
+}

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnection.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnection.java
@@ -170,6 +170,12 @@ public abstract class FireboltConnection extends JdbcBase implements Connection,
 	 */
 	protected abstract boolean isConnectionCachingEnabled();
 
+	/**
+	 * A connection should implement this method if it needs to set additional details on the user agent header for the calls sent to Firebolt backend
+	 * @return
+	 */
+	public abstract Optional<String> getConnectionUserAgentHeader();
+
 	public void removeExpiredTokens() throws SQLException {
 		fireboltAuthenticationService.removeConnectionTokens(httpConnectionUrl, loginProperties);
 	}

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionProvider.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionProvider.java
@@ -82,13 +82,15 @@ public class FireboltConnectionProvider {
         public FireboltConnectionServiceSecret createFireboltConnectionServiceSecret(String url, Properties connectionSettings) throws SQLException {
             CacheServiceProvider cacheServiceProvider = CacheServiceProvider.getInstance();
             // the ON_DISK memory caching will be implemented after
-            return new FireboltConnectionServiceSecret(url, connectionSettings, cacheServiceProvider.getCacheService(CacheType.IN_MEMORY));
+
+            return new FireboltConnectionServiceSecret(url, connectionSettings, ConnectionIdGenerator.getInstance(), cacheServiceProvider.getCacheService(CacheType.DISK));
         }
 
         public LocalhostFireboltConnection createLocalhostFireboltConnectionServiceSecret(String url, Properties connectionSettings) throws SQLException {
             CacheServiceProvider cacheServiceProvider = CacheServiceProvider.getInstance();
             // only in memory caching for localhost connections
-            return new LocalhostFireboltConnection(url, connectionSettings, cacheServiceProvider.getCacheService(CacheType.IN_MEMORY));
+
+            return new LocalhostFireboltConnection(url, connectionSettings, cacheServiceProvider.getCacheService(CacheType.MEMORY));
         }
     }
 

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecret.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecret.java
@@ -27,6 +27,7 @@ import lombok.CustomLog;
 import lombok.NonNull;
 import okhttp3.OkHttpClient;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 
 @CustomLog
 public class FireboltConnectionServiceSecret extends FireboltConnection {
@@ -47,15 +48,14 @@ public class FireboltConnectionServiceSecret extends FireboltConnection {
      */
     private String connectionId;
 
-    FireboltConnectionServiceSecret(@NonNull String url,
-                                    Properties connectionSettings,
+    FireboltConnectionServiceSecret(@NonNull Pair<String, Properties> urlConnectionParams,
                                     FireboltAuthenticationService fireboltAuthenticationService,
                                     FireboltGatewayUrlService fireboltGatewayUrlService,
                                     FireboltStatementService fireboltStatementService,
                                     FireboltEngineVersion2Service fireboltEngineVersion2Service,
                                     ConnectionIdGenerator connectionIdGenerator,
                                     CacheService cacheService) throws SQLException {
-        super(url, connectionSettings, fireboltAuthenticationService, fireboltStatementService, PROTOCOL_VERSION,
+        super(urlConnectionParams.getKey(), urlConnectionParams.getValue(), fireboltAuthenticationService, fireboltStatementService, PROTOCOL_VERSION,
                 ParserVersion.CURRENT);
         this.fireboltGatewayUrlService = fireboltGatewayUrlService;
         this.fireboltEngineVersion2Service = fireboltEngineVersion2Service;

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecret.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecret.java
@@ -26,7 +26,6 @@ import java.util.Properties;
 import lombok.CustomLog;
 import lombok.NonNull;
 import okhttp3.OkHttpClient;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 
 @CustomLog
@@ -54,33 +53,27 @@ public class FireboltConnectionServiceSecret extends FireboltConnection {
                                     FireboltGatewayUrlService fireboltGatewayUrlService,
                                     FireboltStatementService fireboltStatementService,
                                     FireboltEngineVersion2Service fireboltEngineVersion2Service,
+                                    ConnectionIdGenerator connectionIdGenerator,
                                     CacheService cacheService) throws SQLException {
         super(url, connectionSettings, fireboltAuthenticationService, fireboltStatementService, PROTOCOL_VERSION,
                 ParserVersion.CURRENT);
         this.fireboltGatewayUrlService = fireboltGatewayUrlService;
         this.fireboltEngineVersion2Service = fireboltEngineVersion2Service;
-        this.connectionId = generateUniqueConnectionId();
+        this.connectionId = connectionIdGenerator.generateId();
         this.cacheService = cacheService;
         connect();
     }
 
     @ExcludeFromJacocoGeneratedReport
-    FireboltConnectionServiceSecret(@NonNull String url, Properties connectionSettings, CacheService cacheService)
+    FireboltConnectionServiceSecret(@NonNull String url, Properties connectionSettings, ConnectionIdGenerator connectionIdGenerator, CacheService cacheService)
             throws SQLException {
         super(url, connectionSettings, PROTOCOL_VERSION, ParserVersion.CURRENT);
         OkHttpClient httpClient = getHttpClient(loginProperties);
         this.fireboltGatewayUrlService = new FireboltGatewayUrlService(createFireboltAccountRetriever(httpClient, GatewayUrlResponse.class));
         this.fireboltEngineVersion2Service = new FireboltEngineVersion2Service(this);
         this.cacheService = cacheService;
-        this.connectionId = generateUniqueConnectionId();
+        this.connectionId = connectionIdGenerator.generateId();
         connect();
-    }
-
-    /**
-     * Generate a random 12 characters id
-     */
-    private String generateUniqueConnectionId() {
-        return RandomStringUtils.secure().nextAlphanumeric(12);
     }
 
     private <T> FireboltAccountRetriever<T> createFireboltAccountRetriever(OkHttpClient httpClient, Class<T> type) {
@@ -189,6 +182,23 @@ public class FireboltConnectionServiceSecret extends FireboltConnection {
     @Override
     protected boolean isConnectionCachingEnabled() {
         return Boolean.valueOf(loginProperties.isConnectionCachingEnabled());
+    }
+
+    @Override
+    public Optional<String> getConnectionUserAgentHeader() {
+        if (!isConnectionCachingEnabled()) {
+            return Optional.empty();
+        }
+
+        // connection is cached so add the connection info
+        StringBuilder additionalUserAgentHeaderValue = new StringBuilder("connId:").append(connectionId);
+
+        // if the current connectionId is not the same with connection cache, it means that the connection was cached
+        if (!connectionId.equals(connectionCache.getConnectionId())) {
+            additionalUserAgentHeaderValue.append(";cachedConnId:").append(connectionCache.getConnectionId()).append("-").append(connectionCache.getCacheSource());
+        }
+
+        return Optional.of(additionalUserAgentHeaderValue.toString());
     }
 
     protected CacheKey getCacheKey() {

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionUserPassword.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnectionUserPassword.java
@@ -14,6 +14,7 @@ import com.firebolt.jdbc.service.FireboltEngineService;
 import com.firebolt.jdbc.service.FireboltStatementService;
 import com.firebolt.jdbc.type.ParserVersion;
 import java.sql.SQLException;
+import java.util.Optional;
 import java.util.Properties;
 import lombok.CustomLog;
 import lombok.NonNull;
@@ -93,6 +94,11 @@ public class FireboltConnectionUserPassword extends FireboltConnection {
         }
 
         return false;
+    }
+
+    @Override
+    public Optional<String> getConnectionUserAgentHeader() {
+        return Optional.empty();
     }
 
     @Override

--- a/src/main/java/com/firebolt/jdbc/connection/LocalhostFireboltConnection.java
+++ b/src/main/java/com/firebolt/jdbc/connection/LocalhostFireboltConnection.java
@@ -23,7 +23,7 @@ public class LocalhostFireboltConnection extends FireboltConnectionServiceSecret
 
     @ExcludeFromJacocoGeneratedReport
     LocalhostFireboltConnection(@NonNull String url, Properties connectionSettings, CacheService cacheService) throws SQLException {
-        super(url, connectionSettings, cacheService);
+        super(url, connectionSettings, ConnectionIdGenerator.getInstance(), cacheService);
     }
 
     // visible for testing
@@ -33,8 +33,9 @@ public class LocalhostFireboltConnection extends FireboltConnectionServiceSecret
                                 FireboltGatewayUrlService fireboltGatewayUrlService,
                                 FireboltStatementService fireboltStatementService,
                                 FireboltEngineVersion2Service fireboltEngineVersion2Service,
+                                ConnectionIdGenerator connectionIdGenerator,
                                 CacheService cacheService) throws SQLException {
-        super(url, connectionSettings, fireboltAuthenticationService, fireboltGatewayUrlService, fireboltStatementService, fireboltEngineVersion2Service, cacheService);
+        super(url, connectionSettings, fireboltAuthenticationService, fireboltGatewayUrlService, fireboltStatementService, fireboltEngineVersion2Service, connectionIdGenerator, cacheService);
     }
 
     @Override

--- a/src/main/java/com/firebolt/jdbc/connection/LocalhostFireboltConnection.java
+++ b/src/main/java/com/firebolt/jdbc/connection/LocalhostFireboltConnection.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import java.util.Properties;
 import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * A Connection to firebolt that is using localhost as the url of the firebolt server. It will talk to a firebolt 2.0 server.
@@ -27,15 +28,14 @@ public class LocalhostFireboltConnection extends FireboltConnectionServiceSecret
     }
 
     // visible for testing
-    LocalhostFireboltConnection(@NonNull String url,
-                                Properties connectionSettings,
+    LocalhostFireboltConnection(@NonNull Pair<String, Properties> urlConnectionSettings,
                                 FireboltAuthenticationService fireboltAuthenticationService,
                                 FireboltGatewayUrlService fireboltGatewayUrlService,
                                 FireboltStatementService fireboltStatementService,
                                 FireboltEngineVersion2Service fireboltEngineVersion2Service,
                                 ConnectionIdGenerator connectionIdGenerator,
                                 CacheService cacheService) throws SQLException {
-        super(url, connectionSettings, fireboltAuthenticationService, fireboltGatewayUrlService, fireboltStatementService, fireboltEngineVersion2Service, connectionIdGenerator, cacheService);
+        super(urlConnectionSettings, fireboltAuthenticationService, fireboltGatewayUrlService, fireboltStatementService, fireboltEngineVersion2Service, connectionIdGenerator, cacheService);
     }
 
     @Override

--- a/src/test/java/com/firebolt/jdbc/cache/CacheServiceProviderTest.java
+++ b/src/test/java/com/firebolt/jdbc/cache/CacheServiceProviderTest.java
@@ -19,8 +19,8 @@ class CacheServiceProviderTest {
     @Test
     void willReturnTheSameCacheServiceEveryTime() {
         CacheServiceProvider cacheServiceProvider = CacheServiceProvider.getInstance();
-        CacheService cacheService1 = cacheServiceProvider.getCacheService(CacheType.IN_MEMORY);
-        CacheService cacheService2 = cacheServiceProvider.getCacheService(CacheType.IN_MEMORY);
+        CacheService cacheService1 = cacheServiceProvider.getCacheService(CacheType.MEMORY);
+        CacheService cacheService2 = cacheServiceProvider.getCacheService(CacheType.MEMORY);
         assertSame(cacheService1, cacheService2);
         assertInstanceOf(InMemoryCacheService.class, cacheService1);
     }

--- a/src/test/java/com/firebolt/jdbc/client/UsageTrackerUtilTest.java
+++ b/src/test/java/com/firebolt/jdbc/client/UsageTrackerUtilTest.java
@@ -1,5 +1,10 @@
 package com.firebolt.jdbc.client;
 
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -7,16 +12,15 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import java.lang.reflect.Method;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import static com.firebolt.jdbc.client.DriverVersionRetriever.getDriverVersion;
 import static com.firebolt.jdbc.client.UsageTrackerUtil.CLIENT_MAP;
 import static com.firebolt.jdbc.client.UsageTrackerUtil.DRIVER_MAP;
-import static com.firebolt.jdbc.client.UserAgentFormatter.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static com.firebolt.jdbc.client.UserAgentFormatter.javaVersion;
+import static com.firebolt.jdbc.client.UserAgentFormatter.osVersion;
+import static com.firebolt.jdbc.client.UserAgentFormatter.userAgent;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -54,7 +58,7 @@ class UsageTrackerUtilTest {
 	void shouldGetUserAgentNoOverride(String osName, String expectedOsInUserAgent) {
 		System.setProperty("os.name", osName);
 		String result = UsageTrackerUtil.getUserAgentString("", "");
-		assertEquals(userAgent("JDBC/%s (Java %s; %s %s; )", getDriverVersion(), javaVersion(), expectedOsInUserAgent, osVersion()), result);
+		assertEquals(userAgent("JDBC/%s (Java %s; %s %s; )", getDriverVersion(), javaVersion(), expectedOsInUserAgent, osVersion(), Optional.empty()), result);
 	}
 
 	@ParameterizedTest(name = "userClients: {0}")
@@ -65,7 +69,7 @@ class UsageTrackerUtilTest {
 	void shouldGetUserAgentCustomConnectors(String userClients, String expectedPrefix) {
 		System.setProperty("os.name", "MacosX");
 		String result = UsageTrackerUtil.getUserAgentString("AwesomeDriver:1.0.1,BadConnector:0.1.4", userClients);
-		assertEquals(expectedPrefix + userAgent("JDBC/%s (Java %s; %s %s; ) AwesomeDriver/1.0.1 BadConnector/0.1.4", getDriverVersion(), javaVersion(), "Darwin", osVersion()), result);
+		assertEquals(expectedPrefix + userAgent("JDBC/%s (Java %s; %s %s; ) AwesomeDriver/1.0.1 BadConnector/0.1.4", getDriverVersion(), javaVersion(), "Darwin", osVersion(), Optional.empty()), result);
 	}
 
 	@ParameterizedTest(name = "{0} -> {1}")
@@ -79,7 +83,7 @@ class UsageTrackerUtilTest {
 	void shouldIgnoreIncorrectCustomConnectors(String userDrivers, String userClients) {
 		System.setProperty("os.name", "MacosX");
 		String result = UsageTrackerUtil.getUserAgentString(userDrivers, userClients);
-		assertEquals(userAgent("JDBC/%s (Java %s; %s %s; )", getDriverVersion(), javaVersion(), "Darwin", osVersion()), result);
+		assertEquals(userAgent("JDBC/%s (Java %s; %s %s; )", getDriverVersion(), javaVersion(), "Darwin", osVersion(), Optional.empty()), result);
 	}
 
 	@Test

--- a/src/test/java/com/firebolt/jdbc/client/UserAgentFormatter.java
+++ b/src/test/java/com/firebolt/jdbc/client/UserAgentFormatter.java
@@ -1,15 +1,22 @@
 package com.firebolt.jdbc.client;
 
+import java.util.Optional;
+
 public class UserAgentFormatter {
     private static final String VERSION = DriverVersionRetriever.getDriverVersion();
 
     public static String userAgent(String format) {
-        return userAgent(format, VERSION, javaVersion(), osName(), osVersion());
+        return userAgent(format, VERSION, javaVersion(), osName(), osVersion(), Optional.empty());
     }
 
-    public static String userAgent(String format, String driverVersion, String javaVersion, String osName, String osVersion) {
+    public static String userAgent(String format, Optional<String> connectionInfo) {
+        return userAgent(format, VERSION, javaVersion(), osName(), osVersion(), connectionInfo);
+    }
+
+    public static String userAgent(String format, String driverVersion, String javaVersion, String osName, String osVersion, Optional<String> connectionInfo) {
         // Mac OS is renamed to Darwin in the user agent string
-        return String.format(format, driverVersion, javaVersion, osName, osVersion).replace("Mac OS X", "Darwin");
+        String userAgentString =  String.format(format, driverVersion, javaVersion, osName, osVersion).replace("Mac OS X", "Darwin");
+        return connectionInfo.isEmpty() ? userAgentString : userAgentString + connectionInfo.get();
     }
 
     public static String osName() {

--- a/src/test/java/com/firebolt/jdbc/client/query/StatementClientImplTest.java
+++ b/src/test/java/com/firebolt/jdbc/client/query/StatementClientImplTest.java
@@ -112,6 +112,30 @@ class StatementClientImplTest {
 		return Map.entry(statementInfoWrapper.getLabel(), actualRequest.url().toString());
 	}
 
+	@Test
+	void willIncludeUserAgentWithConnectionInfo() throws SQLException, IOException {
+		FireboltProperties fireboltProperties = FireboltProperties.builder().database("db1").compress(true).host("firebolt1").port(555).accountId("12345").systemEngine(false).build();
+		when(connection.getAccessToken()).thenReturn(Optional.of("token"));
+		when(connection.getConnectionUserAgentHeader()).thenReturn(Optional.of("connectionInfo"));
+
+		StatementClient statementClient = new StatementClientImpl(okHttpClient, connection, "ConnA:1.0.9", "ConnB:2.0.9");
+		injectMockedResponse(okHttpClient, 200, "");
+		Call call = getMockedCallWithResponse(200, "");
+		when(okHttpClient.newCall(any())).thenReturn(call);
+		StatementInfoWrapper statementInfoWrapper = StatementUtil.parseToStatementInfoWrappers("show databases").get(0);
+		statementClient.executeSqlStatement(statementInfoWrapper, fireboltProperties, fireboltProperties.isSystemEngine(), 15, false);
+
+		verify(okHttpClient).newCall(requestArgumentCaptor.capture());
+		Request actualRequest = requestArgumentCaptor.getValue();
+		String actualQuery = getActualRequestString(actualRequest);
+		Map<String, String> expectedHeaders = new LinkedHashMap<>();
+		expectedHeaders.put("Authorization", "Bearer token");
+		expectedHeaders.put("User-Agent", userAgent("ConnB/2.0.9 JDBC/%s (Java %s; %s %s; ) ConnA/1.0.9", Optional.of(";connectionInfo"))); // there is an additianal ; in front of the actual text from connection
+		assertEquals(expectedHeaders, extractHeadersMap(actualRequest));
+		assertSqlStatement("show databases;", actualQuery);
+	}
+
+
 	@ParameterizedTest
 	@CsvSource({
 			"true,2,queryLabelFromConnection,true",
@@ -432,6 +456,11 @@ class StatementClientImplTest {
 			@Override
 			protected boolean isConnectionCachingEnabled() {
 				return false;
+			}
+
+			@Override
+			public Optional<String> getConnectionUserAgentHeader() {
+				return Optional.empty();
 			}
 
 		};

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
@@ -419,7 +419,7 @@ class FireboltConnectionServiceSecretTest extends FireboltConnectionTest {
     @Test
     void willAddUserAgentHeaderWhenConnectionIsCachedByThisConnection() throws SQLException {
         // no cache is present for the key
-        lenient().when(mockCacheService.get(cacheKey)).thenReturn(Optional.empty());
+        when(mockCacheService.get(cacheKey)).thenReturn(Optional.empty());
 
         try (FireboltConnectionServiceSecret fireboltConnection = (FireboltConnectionServiceSecret) createConnection(SYSTEM_ENGINE_URL, connectionProperties)) {
             String additionalUserAgentValue = fireboltConnection.getConnectionUserAgentHeader().get();
@@ -433,7 +433,7 @@ class FireboltConnectionServiceSecretTest extends FireboltConnectionTest {
         ConnectionCache connectionCache = new ConnectionCache(ANOTHER_CONNECTION_ID);
         connectionCache.setCacheSource(CacheType.MEMORY.name().toLowerCase());
 
-        lenient().when(mockCacheService.get(cacheKey)).thenReturn(Optional.of(connectionCache));
+        when(mockCacheService.get(cacheKey)).thenReturn(Optional.of(connectionCache));
 
         try (FireboltConnectionServiceSecret fireboltConnection = (FireboltConnectionServiceSecret) createConnection(SYSTEM_ENGINE_URL, connectionProperties)) {
             String additionalUserAgentValue = fireboltConnection.getConnectionUserAgentHeader().get();

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionServiceSecretTest.java
@@ -152,7 +152,7 @@ class FireboltConnectionServiceSecretTest extends FireboltConnectionTest {
         @SuppressWarnings("unchecked") FireboltAccountRetriever<GatewayUrlResponse> fireboltGatewayUrlClient = mock(FireboltAccountRetriever.class);
         when(fireboltGatewayUrlClient.retrieve(any(), any())).thenReturn(new GatewayUrlResponse(gatewayUrl));
         FireboltGatewayUrlService gatewayUrlService = new FireboltGatewayUrlService(fireboltGatewayUrlClient);
-        FireboltConnection connection = new FireboltConnectionServiceSecret(SYSTEM_ENGINE_URL, connectionProperties,
+        FireboltConnection connection = new FireboltConnectionServiceSecret(Pair.of(SYSTEM_ENGINE_URL, connectionProperties),
                 fireboltAuthenticationService, gatewayUrlService, fireboltStatementService, fireboltEngineVersion2Service,
                 mockConnectionIdGenerator, mockCacheService);
         FireboltProperties sessionProperties  = connection.getSessionProperties();
@@ -451,7 +451,7 @@ class FireboltConnectionServiceSecretTest extends FireboltConnectionTest {
     }
 
     protected FireboltConnection createConnection(String url, Properties props) throws SQLException {
-        return new FireboltConnectionServiceSecret(url, props, fireboltAuthenticationService, fireboltGatewayUrlService,
+        return new FireboltConnectionServiceSecret(Pair.of(url, props), fireboltAuthenticationService, fireboltGatewayUrlService,
                 fireboltStatementService, fireboltEngineVersion2Service, mockConnectionIdGenerator, mockCacheService);
     }
 }

--- a/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionUserPasswordTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/FireboltConnectionUserPasswordTest.java
@@ -13,6 +13,7 @@ import static com.firebolt.jdbc.connection.FireboltConnectionUserPassword.SYSTEM
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -105,6 +106,13 @@ class FireboltConnectionUserPasswordTest extends FireboltConnectionTest {
         try (FireboltConnection fireboltConnection = createConnection(url, connectionProperties)) {
             verify(fireboltEngineService).getEngine(argThat(props -> "engine".equals(props.getEngine()) && "db".equals(props.getDatabase())));
             assertEquals("http://my_endpoint", fireboltConnection.getSessionProperties().getHost());
+        }
+    }
+
+    @Test
+    void willNotAddAnyAdditionalUserAgentHeaderValue() throws SQLException {
+        try (FireboltConnection fireboltConnection = createConnection(url, connectionProperties)) {
+            assertTrue(fireboltConnection.getConnectionUserAgentHeader().isEmpty());
         }
     }
 

--- a/src/test/java/com/firebolt/jdbc/connection/LocalhostFireboltConnectionTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/LocalhostFireboltConnectionTest.java
@@ -1,6 +1,10 @@
 package com.firebolt.jdbc.connection;
 
 import com.firebolt.jdbc.cache.CacheService;
+import com.firebolt.jdbc.cache.CacheType;
+import com.firebolt.jdbc.cache.ConnectionCache;
+import com.firebolt.jdbc.cache.key.CacheKey;
+import com.firebolt.jdbc.cache.key.LocalhostCacheKey;
 import com.firebolt.jdbc.connection.settings.FireboltProperties;
 import com.firebolt.jdbc.exception.FireboltException;
 import com.firebolt.jdbc.service.FireboltAuthenticationService;
@@ -8,6 +12,7 @@ import com.firebolt.jdbc.service.FireboltEngineVersion2Service;
 import com.firebolt.jdbc.service.FireboltGatewayUrlService;
 import com.firebolt.jdbc.service.FireboltStatementService;
 import java.sql.SQLException;
+import java.util.Optional;
 import java.util.Properties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,6 +30,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -34,6 +40,9 @@ class LocalhostFireboltConnectionTest {
     private static final String URL = "jdbc:firebolt:db?env=dev&engine=eng&account=dev";
     private static final String URL_WITHOUT_ACCOUNT = "jdbc:firebolt:db?env=dev&engine=eng";
     private static final String LOCAL_URL = "jdbc:firebolt:local_dev_db?account=dev&ssl=false&max_query_size=10000000&mask_internal_errors=0&host=localhost";
+
+    private static final String CONNECTION_ID = "abc";
+    private static final String CONNECTION_ID_2 = "def";
 
     @Mock
     private FireboltAuthenticationService fireboltAuthenticationService;
@@ -45,7 +54,10 @@ class LocalhostFireboltConnectionTest {
     private FireboltStatementService fireboltStatementService;
     @Mock
     private CacheService cacheService;
+    @Mock
+    private ConnectionIdGenerator mockConnectionIdGenerator;
 
+    private CacheKey cacheKey;
     private Properties connectionProperties;
 
     @BeforeEach
@@ -55,6 +67,9 @@ class LocalhostFireboltConnectionTest {
         connectionProperties.setProperty("account", "account");
         connectionProperties.setProperty("user", "myuser@email.com");
         connectionProperties.setProperty("password", "password");
+
+        cacheKey = new LocalhostCacheKey("the token");
+        when(mockConnectionIdGenerator.generateId()).thenReturn(CONNECTION_ID);
     }
 
     @ParameterizedTest
@@ -160,9 +175,48 @@ class LocalhostFireboltConnectionTest {
         }
     }
 
+    @Test
+    void willNotAddAdditionalUserAgentHeaderValuesIfConnectionIsNotCachable() throws SQLException{
+        disableCacheConnection();
+        try (FireboltConnection fireboltConnection = createConnection(LOCAL_URL, connectionProperties)) {
+            assertTrue(fireboltConnection.getConnectionUserAgentHeader().isEmpty());
+        }
+    }
+
+    @Test
+    void willAddUserAgentHeaderWhenConnectionIsCachedByThisConnection() throws SQLException {
+        // no cache is present for the key
+        lenient().when(cacheService.get(cacheKey)).thenReturn(Optional.empty());
+
+        try (FireboltConnectionServiceSecret fireboltConnection = (FireboltConnectionServiceSecret) createConnection(LOCAL_URL, connectionProperties)) {
+            String additionalUserAgentValue = fireboltConnection.getConnectionUserAgentHeader().get();
+            assertEquals("connId:" + CONNECTION_ID, additionalUserAgentValue);
+        }
+    }
+
+    @Test
+    void willAddUserAgentHeaderWhenConnectionIsCachedByAPreviousConnection() throws SQLException {
+        // connection is already cached
+        ConnectionCache connectionCache = new ConnectionCache(CONNECTION_ID_2);
+        connectionCache.setCacheSource(CacheType.MEMORY.name().toLowerCase());
+
+        lenient().when(cacheService.get(cacheKey)).thenReturn(Optional.of(connectionCache));
+
+        try (FireboltConnectionServiceSecret fireboltConnection = (FireboltConnectionServiceSecret) createConnection(LOCAL_URL, connectionProperties)) {
+            String additionalUserAgentValue = fireboltConnection.getConnectionUserAgentHeader().get();
+            String expectedUserAgent = "connId:" + CONNECTION_ID + ";cachedConnId:" + CONNECTION_ID_2 +"-memory";
+            assertEquals(expectedUserAgent, additionalUserAgentValue);
+        }
+    }
+
+    private void disableCacheConnection() {
+        connectionProperties.put("cache_connection", "none");
+    }
+
+
     protected FireboltConnection createConnection(String url, Properties props) throws SQLException {
         return new LocalhostFireboltConnection(url, props, fireboltAuthenticationService, fireboltGatewayUrlService,
-                fireboltStatementService, fireboltEngineVersion2Service, cacheService);
+                fireboltStatementService, fireboltEngineVersion2Service, mockConnectionIdGenerator, cacheService);
 
     }
 }

--- a/src/test/java/com/firebolt/jdbc/connection/LocalhostFireboltConnectionTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/LocalhostFireboltConnectionTest.java
@@ -14,6 +14,7 @@ import com.firebolt.jdbc.service.FireboltStatementService;
 import java.sql.SQLException;
 import java.util.Optional;
 import java.util.Properties;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -214,7 +215,7 @@ class LocalhostFireboltConnectionTest {
 
 
     protected FireboltConnection createConnection(String url, Properties props) throws SQLException {
-        return new LocalhostFireboltConnection(url, props, fireboltAuthenticationService, fireboltGatewayUrlService,
+        return new LocalhostFireboltConnection(Pair.of(url, props), fireboltAuthenticationService, fireboltGatewayUrlService,
                 fireboltStatementService, fireboltEngineVersion2Service, mockConnectionIdGenerator, cacheService);
 
     }

--- a/src/test/java/com/firebolt/jdbc/connection/LocalhostFireboltConnectionTest.java
+++ b/src/test/java/com/firebolt/jdbc/connection/LocalhostFireboltConnectionTest.java
@@ -30,7 +30,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -186,7 +185,7 @@ class LocalhostFireboltConnectionTest {
     @Test
     void willAddUserAgentHeaderWhenConnectionIsCachedByThisConnection() throws SQLException {
         // no cache is present for the key
-        lenient().when(cacheService.get(cacheKey)).thenReturn(Optional.empty());
+        when(cacheService.get(cacheKey)).thenReturn(Optional.empty());
 
         try (FireboltConnectionServiceSecret fireboltConnection = (FireboltConnectionServiceSecret) createConnection(LOCAL_URL, connectionProperties)) {
             String additionalUserAgentValue = fireboltConnection.getConnectionUserAgentHeader().get();
@@ -200,7 +199,7 @@ class LocalhostFireboltConnectionTest {
         ConnectionCache connectionCache = new ConnectionCache(CONNECTION_ID_2);
         connectionCache.setCacheSource(CacheType.MEMORY.name().toLowerCase());
 
-        lenient().when(cacheService.get(cacheKey)).thenReturn(Optional.of(connectionCache));
+        when(cacheService.get(cacheKey)).thenReturn(Optional.of(connectionCache));
 
         try (FireboltConnectionServiceSecret fireboltConnection = (FireboltConnectionServiceSecret) createConnection(LOCAL_URL, connectionProperties)) {
             String additionalUserAgentValue = fireboltConnection.getConnectionUserAgentHeader().get();


### PR DESCRIPTION
Adde connection information to the user-agent hearer:
- if connection is not cached and created the first time then only: connId:<xxx> will be added
- if the connection was using cached data then we add: connId:<abc>;cachedConnId:<yyy> where yyy is the connection id that tested the connection. 

Seems like integration tests are all using cached connections (which is a good thing) and they are passing:
