### PR TITLE
fix: FIR-44784 Fix boolean in prepared statements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ dependencies {
     testImplementation 'io.zonky.test:embedded-postgres:2.1.0'
     testCompileOnly 'org.slf4j:slf4j-api:2.0.17'
     testCommonImplementation 'org.junit.jupiter:junit-jupiter-api:5.12.1'
+    testCommonImplementation 'org.junit.jupiter:junit-jupiter-params:5.12.1'
     testImplementation sourceSets.testCommon.output
     compileTestJava.dependsOn processTestResources
     jar.dependsOn processTestResources

--- a/src/integrationTest/java/integration/tests/PreparedStatementTest.java
+++ b/src/integrationTest/java/integration/tests/PreparedStatementTest.java
@@ -12,9 +12,9 @@ import lombok.Builder;
 import lombok.CustomLog;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.junit.Ignore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -612,9 +612,9 @@ class PreparedStatementTest extends IntegrationTest {
 		}
 	}
 
-	@Ignore
+	@Disabled
 	@ParameterizedTest
-	@MethodSource("booleanTypes")
+	@MethodSource("com.firebolt.jdbc.testutils.TestFixtures#booleanTypes")
 	void shouldFetchBooleanFromVariousObjects(Object objectTrue, Object objectFalse) throws SQLException {
 		try (Connection connection = createConnection()) {
 			try (PreparedStatement statement = connection
@@ -632,26 +632,6 @@ class PreparedStatementTest extends IntegrationTest {
 				assertFalse(rs.getBoolean(2));
 			}
 		}
-	}
-
-	Stream<Arguments> booleanTypes() {
-		return Stream.of(
-				Arguments.of("1", "0"),
-				Arguments.of("true", "false"),
-				Arguments.of("t", "f"),
-				Arguments.of("yes", "no"),
-				Arguments.of("y", "n"),
-				Arguments.of("on", "off"),
-				Arguments.of('1', '0'),
-				Arguments.of('t', 'f'),
-				Arguments.of('T', 'F'),
-				Arguments.of('y', 'n'),
-				Arguments.of('Y', 'N'),
-				Arguments.of(1, 0),
-				Arguments.of(1.0, 0.0),
-				Arguments.of(1F, 0F),
-				Arguments.of(1L, 0L)
-		);
 	}
 
 	Stream<Arguments> dateTypes() {

--- a/src/integrationTest/java/integration/tests/PreparedStatementTest.java
+++ b/src/integrationTest/java/integration/tests/PreparedStatementTest.java
@@ -12,6 +12,7 @@ import lombok.Builder;
 import lombok.CustomLog;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.junit.Ignore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -38,8 +39,6 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -587,6 +586,72 @@ class PreparedStatementTest extends IntegrationTest {
 				assertEquals("don't", rs.getString(4));
 			}
 		}
+	}
+
+	@Test
+	void shouldFetchBoolean() throws SQLException {
+		try (Connection connection = createConnection()) {
+			try (PreparedStatement statement = connection
+					.prepareStatement("SELECT ? as a, ? as b, ? as c")) {
+				statement.setBoolean(1, true);
+				statement.setObject(2, false);
+				statement.setObject(3, true, Types.BOOLEAN);
+				statement.execute();
+				ResultSet rs = statement.getResultSet();
+				assertEquals(FireboltDataType.BOOLEAN.name().toLowerCase(),
+						rs.getMetaData().getColumnTypeName(1).toLowerCase());
+				assertEquals(FireboltDataType.BOOLEAN.name().toLowerCase(),
+						rs.getMetaData().getColumnTypeName(2).toLowerCase());
+				assertEquals(FireboltDataType.BOOLEAN.name().toLowerCase(),
+						rs.getMetaData().getColumnTypeName(3).toLowerCase());
+				assertTrue(rs.next());
+				assertTrue(rs.getBoolean(1));
+				assertFalse(rs.getBoolean(2));
+				assertTrue(rs.getBoolean(3));
+			}
+		}
+	}
+
+	@Ignore
+	@ParameterizedTest
+	@MethodSource("booleanTypes")
+	void shouldFetchBooleanFromVariousObjects(Object objectTrue, Object objectFalse) throws SQLException {
+		try (Connection connection = createConnection()) {
+			try (PreparedStatement statement = connection
+					.prepareStatement("SELECT ? as a, ? as b")) {
+				statement.setObject(1, objectTrue, Types.BOOLEAN);
+				statement.setObject(2, objectFalse, Types.BOOLEAN);
+				statement.execute();
+				ResultSet rs = statement.getResultSet();
+				assertEquals(FireboltDataType.BOOLEAN.name().toLowerCase(),
+						rs.getMetaData().getColumnTypeName(1).toLowerCase());
+				assertEquals(FireboltDataType.BOOLEAN.name().toLowerCase(),
+						rs.getMetaData().getColumnTypeName(2).toLowerCase());
+				assertTrue(rs.next());
+				assertTrue(rs.getBoolean(1));
+				assertFalse(rs.getBoolean(2));
+			}
+		}
+	}
+
+	Stream<Arguments> booleanTypes() {
+		return Stream.of(
+				Arguments.of("1", "0"),
+				Arguments.of("true", "false"),
+				Arguments.of("t", "f"),
+				Arguments.of("yes", "no"),
+				Arguments.of("y", "n"),
+				Arguments.of("on", "off"),
+				Arguments.of('1', '0'),
+				Arguments.of('t', 'f'),
+				Arguments.of('T', 'F'),
+				Arguments.of('y', 'n'),
+				Arguments.of('Y', 'N'),
+				Arguments.of(1, 0),
+				Arguments.of(1.0, 0.0),
+				Arguments.of(1F, 0F),
+				Arguments.of(1L, 0L)
+		);
 	}
 
 	Stream<Arguments> dateTypes() {

--- a/src/integrationTest/java/integration/tests/PreparedStatementTest.java
+++ b/src/integrationTest/java/integration/tests/PreparedStatementTest.java
@@ -636,11 +636,11 @@ class PreparedStatementTest extends IntegrationTest {
 
 	Stream<Arguments> dateTypes() {
 		return Stream.of(
-				Arguments.of(LocalDateTime.of(2019, 7, 31, 14, 15, 13),
+				Arguments.of(new Timestamp(1564571713000L).toLocalDateTime(),
 						LocalDate.of(2019, 7, 31), true),
 				Arguments.of(new Timestamp(1564571713000L),
 						new Date(1564527600000L), true),
-				Arguments.of(LocalDateTime.of(2019, 7, 31, 14, 15, 13),
+				Arguments.of(new Timestamp(1564571713000L).toLocalDateTime(),
 						LocalDate.of(2019, 7, 31), false),
 				Arguments.of(new Timestamp(1564571713000L),
 						new Date(1564527600000L), false)

--- a/src/main/java/com/firebolt/jdbc/type/BooleanTypeUtil.java
+++ b/src/main/java/com/firebolt/jdbc/type/BooleanTypeUtil.java
@@ -1,0 +1,88 @@
+package com.firebolt.jdbc.type;
+
+import com.firebolt.jdbc.exception.FireboltException;
+import lombok.CustomLog;
+
+import static java.lang.String.format;
+
+@CustomLog
+class BooleanTypeUtil {
+
+    private BooleanTypeUtil() {
+    }
+
+    static String castToFireboltBoolean(Object value) throws FireboltException {
+        return castToBoolean(value) ? "true" : "false";
+    }
+
+    /**
+     * Cast an Object value to the corresponding boolean value.
+     *
+     * @param in Object to cast into boolean
+     * @return boolean value corresponding to the cast of the object
+     * @throws FireboltException cannot
+     */
+    @SuppressWarnings("java:S6201")
+    static boolean castToBoolean(final Object in) throws FireboltException {
+        log.debug("Cast to boolean: \"{0}\"", String.valueOf(in));
+        if (in instanceof Boolean) {
+            return (Boolean) in;
+        }
+        if (in instanceof String) {
+            return fromString((String) in);
+        }
+        if (in instanceof Character) {
+            return fromCharacter((Character) in);
+        }
+        if (in instanceof Number) {
+            return fromNumber((Number) in);
+        }
+        throw new FireboltException(format("Cannot cast %s to boolean", in));
+    }
+
+    static boolean fromString(final String strval) throws FireboltException {
+        // Leading or trailing whitespace is ignored, and case does not matter.
+        final String val = strval.trim();
+        if ("1".equals(val) || "true".equalsIgnoreCase(val)
+                || "t".equalsIgnoreCase(val) || "yes".equalsIgnoreCase(val)
+                || "y".equalsIgnoreCase(val) || "on".equalsIgnoreCase(val)) {
+            return true;
+        }
+        if ("0".equals(val) || "false".equalsIgnoreCase(val)
+                || "f".equalsIgnoreCase(val) || "no".equalsIgnoreCase(val)
+                || "n".equalsIgnoreCase(val) || "off".equalsIgnoreCase(val)) {
+            return false;
+        }
+        throw cannotCastException(strval);
+    }
+
+    private static boolean fromCharacter(final Character charval) throws FireboltException {
+        if ('1' == charval || 't' == charval || 'T' == charval
+                || 'y' == charval || 'Y' == charval) {
+            return true;
+        }
+        if ('0' == charval || 'f' == charval || 'F' == charval
+                || 'n' == charval || 'N' == charval) {
+            return false;
+        }
+        throw cannotCastException(charval);
+    }
+
+    private static boolean fromNumber(final Number numval) throws FireboltException {
+        // Handles BigDecimal, Byte, Short, Integer, Long Float, Double
+        // based on the widening primitive conversions.
+        final double value = numval.doubleValue();
+        if (value == 1.0d) {
+            return true;
+        }
+        if (value == 0.0d) {
+            return false;
+        }
+        throw cannotCastException(numval);
+    }
+
+    private static FireboltException cannotCastException(final Object value) {
+        return new FireboltException(format("Cannot cast to boolean: \"%s\"", value));
+    }
+
+}

--- a/src/main/java/com/firebolt/jdbc/type/BooleanTypeUtil.java
+++ b/src/main/java/com/firebolt/jdbc/type/BooleanTypeUtil.java
@@ -69,7 +69,7 @@ class BooleanTypeUtil {
     }
 
     private static boolean fromNumber(final Number numval) throws FireboltException {
-        // Handles BigDecimal, Byte, Short, Integer, Long Float, Double
+        // Handles BigDecimal, Byte, Short, Integer, Long, Float, Double
         // based on the widening primitive conversions.
         final double value = numval.doubleValue();
         if (value == 1.0d) {

--- a/src/main/java/com/firebolt/jdbc/type/BooleanTypeUtil.java
+++ b/src/main/java/com/firebolt/jdbc/type/BooleanTypeUtil.java
@@ -22,7 +22,7 @@ class BooleanTypeUtil {
      * @return boolean value corresponding to the cast of the object
      * @throws FireboltException cannot
      */
-    @SuppressWarnings("java:S6201")
+    @SuppressWarnings("java:S6201") // Pattern Matching for "instanceof" was introduced in java 16 while we still try to be compliant with java 11
     static boolean castToBoolean(final Object in) throws FireboltException {
         log.debug("Cast to boolean: \"{0}\"", String.valueOf(in));
         if (in instanceof Boolean) {

--- a/src/main/java/com/firebolt/jdbc/type/JavaTypeToFireboltSQLString.java
+++ b/src/main/java/com/firebolt/jdbc/type/JavaTypeToFireboltSQLString.java
@@ -34,7 +34,7 @@ import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toMap;
 
 public enum JavaTypeToFireboltSQLString {
-	BOOLEAN(Boolean.class, value -> Boolean.TRUE.equals(value) ? "1" : "0"),
+	BOOLEAN(Boolean.class, BooleanTypeUtil::castToFireboltBoolean),
 	UUID(java.util.UUID.class, Object::toString),
 	BYTE(Byte.class, value -> Byte.toString(((Number) value).byteValue())),
 	SHORT(Short.class, value -> Short.toString(((Number) value).shortValue())),

--- a/src/test/java/com/firebolt/jdbc/statement/preparedstatement/FireboltPreparedStatementTest.java
+++ b/src/test/java/com/firebolt/jdbc/statement/preparedstatement/FireboltPreparedStatementTest.java
@@ -407,7 +407,7 @@ class FireboltPreparedStatementTest {
 		statement.execute();
 
 		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties), any());
-		assertEquals("INSERT INTO cars(available) VALUES (1)", queryInfoWrapperArgumentCaptor.getValue().getSql());
+		assertEquals("INSERT INTO cars(available) VALUES (true)", queryInfoWrapperArgumentCaptor.getValue().getSql());
 	}
 
 	@ParameterizedTest
@@ -547,7 +547,7 @@ class FireboltPreparedStatementTest {
 
 		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties), any());
 		assertEquals(
-				"INSERT INTO cars(timestamp, date, float, long, big_decimal, null, boolean, int) VALUES ('2019-07-31 12:15:13','2019-07-31',5.5,5,555555555555.55555555,NULL,1,5)",
+				"INSERT INTO cars(timestamp, date, float, long, big_decimal, null, boolean, int) VALUES ('2019-07-31 12:15:13','2019-07-31',5.5,5,555555555555.55555555,NULL,true,5)",
 				queryInfoWrapperArgumentCaptor.getValue().getSql());
 	}
 
@@ -573,7 +573,7 @@ class FireboltPreparedStatementTest {
 		verify(fireboltStatementService).execute(queryInfoWrapperArgumentCaptor.capture(), eq(properties), any());
 
 		assertEquals(
-				"INSERT INTO cars(timestamp, date, float, long, big_decimal, null, boolean, int) VALUES ('2019-07-31 12:15:13','2019-07-31',5.5,5,555555555555.55555555,NULL,1,5)",
+				"INSERT INTO cars(timestamp, date, float, long, big_decimal, null, boolean, int) VALUES ('2019-07-31 12:15:13','2019-07-31',5.5,5,555555555555.55555555,NULL,true,5)",
 				queryInfoWrapperArgumentCaptor.getValue().getSql());
 	}
 

--- a/src/test/java/com/firebolt/jdbc/type/JavaTypeToFireboltSQLStringTest.java
+++ b/src/test/java/com/firebolt/jdbc/type/JavaTypeToFireboltSQLStringTest.java
@@ -39,9 +39,9 @@ class JavaTypeToFireboltSQLStringTest {
 
 	@Test
 	void shouldTransformBooleanToString() throws SQLException {
-		assertEquals("1", JavaTypeToFireboltSQLString.BOOLEAN.transform(true));
+		assertEquals("true", JavaTypeToFireboltSQLString.BOOLEAN.transform(true));
 
-		assertEquals("0", JavaTypeToFireboltSQLString.BOOLEAN.transform(false));
+		assertEquals("false", JavaTypeToFireboltSQLString.BOOLEAN.transform(false));
 
 		assertEquals("NULL", JavaTypeToFireboltSQLString.BOOLEAN.transform(null));
 	}

--- a/src/test/java/com/firebolt/jdbc/type/JavaTypeToFireboltSQLStringTest.java
+++ b/src/test/java/com/firebolt/jdbc/type/JavaTypeToFireboltSQLStringTest.java
@@ -240,30 +240,9 @@ class JavaTypeToFireboltSQLStringTest {
 	}
 
 	@ParameterizedTest
-	@MethodSource("booleanTypes")
+	@MethodSource("com.firebolt.jdbc.testutils.TestFixtures#booleanTypes")
 	void shouldTransformBooleanTypes(Object trueValue, Object falseValue) throws SQLException {
 		assertEquals("true", JavaTypeToFireboltSQLString.BOOLEAN.transform(trueValue));
 		assertEquals("false", JavaTypeToFireboltSQLString.BOOLEAN.transform(falseValue));
-	}
-
-	Stream<Arguments> booleanTypes() {
-		return Stream.of(
-				Arguments.of("1", "0"),
-				Arguments.of("true", "false"),
-				Arguments.of("t", "f"),
-				Arguments.of("yes", "no"),
-				Arguments.of("y", "n"),
-				Arguments.of("on", "off"),
-				Arguments.of('1', '0'),
-				Arguments.of('t', 'f'),
-				Arguments.of('T', 'F'),
-				Arguments.of('y', 'n'),
-				Arguments.of('Y', 'N'),
-				Arguments.of(1, 0),
-				Arguments.of(1.0, 0.0),
-				Arguments.of(1F, 0F),
-				Arguments.of(1L, 0L),
-				Arguments.of(BigDecimal.valueOf(1), BigDecimal.valueOf(0))
-		);
 	}
 }

--- a/src/test/java/com/firebolt/jdbc/type/JavaTypeToFireboltSQLStringTest.java
+++ b/src/test/java/com/firebolt/jdbc/type/JavaTypeToFireboltSQLStringTest.java
@@ -7,12 +7,10 @@ import com.firebolt.jdbc.type.array.SqlArrayUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junitpioneer.jupiter.DefaultTimeZone;
 
-import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -21,7 +19,6 @@ import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import static com.firebolt.jdbc.exception.ExceptionType.TYPE_NOT_SUPPORTED;
 import static com.firebolt.jdbc.exception.ExceptionType.TYPE_TRANSFORMATION_ERROR;

--- a/src/test/java/com/firebolt/jdbc/type/JavaTypeToFireboltSQLStringTest.java
+++ b/src/test/java/com/firebolt/jdbc/type/JavaTypeToFireboltSQLStringTest.java
@@ -5,10 +5,14 @@ import com.firebolt.jdbc.resultset.column.ColumnType;
 import com.firebolt.jdbc.type.array.FireboltArray;
 import com.firebolt.jdbc.type.array.SqlArrayUtil;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junitpioneer.jupiter.DefaultTimeZone;
 
+import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -17,6 +21,7 @@ import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static com.firebolt.jdbc.exception.ExceptionType.TYPE_NOT_SUPPORTED;
 import static com.firebolt.jdbc.exception.ExceptionType.TYPE_TRANSFORMATION_ERROR;
@@ -24,6 +29,7 @@ import static com.firebolt.jdbc.type.JavaTypeToFireboltSQLString.NULL_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class JavaTypeToFireboltSQLStringTest {
 
 	@Test
@@ -231,5 +237,33 @@ class JavaTypeToFireboltSQLStringTest {
 	@EnumSource(JavaTypeToFireboltSQLString.class)
 	void shouldTransformNullValue(JavaTypeToFireboltSQLString type) throws SQLException {
 		assertEquals(NULL_VALUE, type.transform(null));
+	}
+
+	@ParameterizedTest
+	@MethodSource("booleanTypes")
+	void shouldTransformBooleanTypes(Object trueValue, Object falseValue) throws SQLException {
+		assertEquals("true", JavaTypeToFireboltSQLString.BOOLEAN.transform(trueValue));
+		assertEquals("false", JavaTypeToFireboltSQLString.BOOLEAN.transform(falseValue));
+	}
+
+	Stream<Arguments> booleanTypes() {
+		return Stream.of(
+				Arguments.of("1", "0"),
+				Arguments.of("true", "false"),
+				Arguments.of("t", "f"),
+				Arguments.of("yes", "no"),
+				Arguments.of("y", "n"),
+				Arguments.of("on", "off"),
+				Arguments.of('1', '0'),
+				Arguments.of('t', 'f'),
+				Arguments.of('T', 'F'),
+				Arguments.of('y', 'n'),
+				Arguments.of('Y', 'N'),
+				Arguments.of(1, 0),
+				Arguments.of(1.0, 0.0),
+				Arguments.of(1F, 0F),
+				Arguments.of(1L, 0L),
+				Arguments.of(BigDecimal.valueOf(1), BigDecimal.valueOf(0))
+		);
 	}
 }

--- a/src/testCommon/java/com/firebolt/jdbc/testutils/TestFixtures.java
+++ b/src/testCommon/java/com/firebolt/jdbc/testutils/TestFixtures.java
@@ -1,0 +1,27 @@
+package com.firebolt.jdbc.testutils;
+
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.util.stream.Stream;
+
+public class TestFixtures {
+    public static Stream<Arguments> booleanTypes() {
+        return Stream.of(
+                Arguments.of("1", "0"),
+                Arguments.of("true", "false"),
+                Arguments.of("t", "f"),
+                Arguments.of("yes", "no"),
+                Arguments.of("y", "n"),
+                Arguments.of("on", "off"),
+                Arguments.of('1', '0'),
+                Arguments.of('t', 'f'),
+                Arguments.of('T', 'F'),
+                Arguments.of('y', 'n'),
+                Arguments.of('Y', 'N'),
+                Arguments.of(1, 0),
+                Arguments.of(1.0, 0.0),
+                Arguments.of(1F, 0F),
+                Arguments.of(1L, 0L)
+        );
+    }
+}


### PR DESCRIPTION
Added a specialized class to handle all sorts of conversions from String, Numbers and Characters to Boolean.
Created tests for this method but in the current configuration of our transformer they do not work. 
We will need to update it to align ourself with the JDBC spec.
For the moment, setObject for a boolean outcome only work from a boolean object.