### PR TITLE
FID-44260 added class to resolve default temp directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ test {
             "--add-opens=java.base/java.util=ALL-UNNAMED"
     ) // so we can change the environment variables
     useJUnitPlatform()
-    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+    maxParallelForks = 1
     testLogging {
         events 'PASSED', 'FAILED', 'SKIPPED'
         exceptionFormat = 'full'

--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,10 @@ dependencies {
 }
 
 test {
+    jvmArgs(
+            "--add-opens=java.base/java.lang=ALL-UNNAMED",
+            "--add-opens=java.base/java.util=ALL-UNNAMED"
+    ) // so we can change the environment variables
     useJUnitPlatform()
     maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
     testLogging {
@@ -224,6 +228,7 @@ task printVersion {
 }
 sonarqube {
     properties {
+        property "sonar.java.source", "11"
         property "sonar.projectKey", "firebolt-db_jdbc"
         property "sonar.organization", "firebolt-db"
         property "sonar.host.url", "https://sonarcloud.io"

--- a/src/main/java/com/firebolt/jdbc/cache/DirectoryPathResolver.java
+++ b/src/main/java/com/firebolt/jdbc/cache/DirectoryPathResolver.java
@@ -1,0 +1,64 @@
+package com.firebolt.jdbc.cache;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import lombok.CustomLog;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Based on different operating systems, it resolves the path to the directory where an application can write to disk
+ */
+@CustomLog
+public class DirectoryPathResolver {
+
+    private static final String FIREBOLT_DRIVER_DIRECTORY_NAME = "fireboltDriver";
+
+    public static final String USER_HOME_PROPERTY = "user.home";
+    public static final String OS_NAME_PROPERTY = "os.name";
+    public static final String TEMP_DIRECTORY_PROPERTY = "java.io.tmpdir";
+
+    /**
+     * We will default to writing the connection cache data in the default temp directory for each operating system
+     * It will make sure that the directory is crated.
+     * @return
+     */
+    public Path resolveFireboltJdbcDirectory() {
+        String osName = System.getProperty(OS_NAME_PROPERTY).toLowerCase();
+        Path fireboltJdbcDirectory = getDefaultDirectoryPath(osName);
+
+        // Ensure cache directory exists
+        try {
+            Files.createDirectories(fireboltJdbcDirectory);
+        } catch (IOException e) {
+            log.error("Failed to create the cached directory.");
+        }
+
+        return fireboltJdbcDirectory;
+    }
+
+    /**
+     * Returns the default directory name for an operating system
+     * @param osName - the name of the operating system
+     * @return
+     */
+    @SuppressWarnings("java:S5443") // we are writing to temp directory but the file name is encrypted and so is the content
+    private Path getDefaultDirectoryPath(String osName) {
+        if (osName.contains("win")) {
+            return Paths.get(System.getProperty(TEMP_DIRECTORY_PROPERTY), FIREBOLT_DRIVER_DIRECTORY_NAME);
+        } else if (osName.contains("mac")) {
+            // this is per user and will be deleted upon reboot or when the OS needs more disk space
+            String tempDirectory = System.getenv("TMPDIR");
+            return Path.of(tempDirectory, FIREBOLT_DRIVER_DIRECTORY_NAME);
+        } else {
+            // for linux try the user specific temp directory. If that is not set then use the /tmp
+            String tempUserDirectory = System.getenv("XDG_RUNTIME_DIR");
+            if (StringUtils.isBlank(tempUserDirectory)) {
+                tempUserDirectory = Path.of("/tmp", System.getProperty(USER_HOME_PROPERTY)).toString(); // Fallback if not set
+            }
+            return Path.of(tempUserDirectory, FIREBOLT_DRIVER_DIRECTORY_NAME);
+        }
+    }
+
+}

--- a/src/test/java/com/firebolt/jdbc/cache/DirectoryPathResolverTest.java
+++ b/src/test/java/com/firebolt/jdbc/cache/DirectoryPathResolverTest.java
@@ -1,0 +1,63 @@
+package com.firebolt.jdbc.cache;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// The tests are disabled since they interfere with the other test classes (tests are run in parallel and mockito creates file in the temp location,
+// which we modify in these tests, so the other tests would randomly fail)
+@Disabled
+class DirectoryPathResolverTest {
+
+    private static String originalUserHome;
+    private static String originalOsName;
+
+    private DirectoryPathResolver directoryPathResolver = new DirectoryPathResolver();
+
+    @BeforeAll
+    static void setupClass() {
+        originalUserHome = System.getProperty(DirectoryPathResolver.USER_HOME_PROPERTY);
+        originalOsName = System.getProperty(DirectoryPathResolver.OS_NAME_PROPERTY);
+    }
+
+    @AfterAll
+    static void tearDownClass() {
+        // set back the original properties
+        System.setProperty(DirectoryPathResolver.USER_HOME_PROPERTY, originalUserHome);
+        System.setProperty(DirectoryPathResolver.OS_NAME_PROPERTY, originalOsName);
+    }
+
+    @Test
+    void canCreateFireboltDirectoryForWindows() {
+        System.setProperty(DirectoryPathResolver.OS_NAME_PROPERTY,"windows 11");
+        System.setProperty(DirectoryPathResolver.TEMP_DIRECTORY_PROPERTY, "/temp");
+        assertEquals("/temp/fireboltDriver", directoryPathResolver.resolveFireboltJdbcDirectory().toString());
+    }
+
+    @Test
+    @SetEnvironmentVariable(key="TMPDIR", value="/temp/xx/1234")
+    void canCreateFireboltDirectoryForMac() {
+       System.setProperty(DirectoryPathResolver.OS_NAME_PROPERTY,"mac osx 18");
+       assertEquals("/temp/xx/1234/fireboltDriver", directoryPathResolver.resolveFireboltJdbcDirectory().toString());
+    }
+
+    @Test
+    void canCreateFireboltDirectoryForLinux() {
+        System.setProperty(DirectoryPathResolver.USER_HOME_PROPERTY, "/Users/testuser");
+        System.setProperty(DirectoryPathResolver.OS_NAME_PROPERTY,"linux");
+        assertEquals("/tmp/Users/testuser/fireboltDriver", directoryPathResolver.resolveFireboltJdbcDirectory().toString());
+    }
+
+    @Test
+    @SetEnvironmentVariable(key="XDG_RUNTIME_DIR", value="/temp/xx/5678")
+    void canCreateFireboltDirectoryForLinuxWhenUserTempDirectoryIsSet() {
+        System.setProperty(DirectoryPathResolver.USER_HOME_PROPERTY, "/Users/testuser");
+        System.setProperty(DirectoryPathResolver.OS_NAME_PROPERTY,"linux");
+        assertEquals("/temp/xx/5678/fireboltDriver", directoryPathResolver.resolveFireboltJdbcDirectory().toString());
+    }
+
+}

--- a/src/test/java/com/firebolt/jdbc/cache/DirectoryPathResolverTest.java
+++ b/src/test/java/com/firebolt/jdbc/cache/DirectoryPathResolverTest.java
@@ -2,15 +2,11 @@ package com.firebolt.jdbc.cache;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-// The tests are disabled since they interfere with the other test classes (tests are run in parallel and mockito creates file in the temp location,
-// which we modify in these tests, so the other tests would randomly fail)
-@Disabled
 class DirectoryPathResolverTest {
 
     private static String originalUserHome;
@@ -46,6 +42,7 @@ class DirectoryPathResolverTest {
     }
 
     @Test
+    @SetEnvironmentVariable(key="XDG_RUNTIME_DIR", value="")
     void canCreateFireboltDirectoryForLinux() {
         System.setProperty(DirectoryPathResolver.USER_HOME_PROPERTY, "/Users/testuser");
         System.setProperty(DirectoryPathResolver.OS_NAME_PROPERTY,"linux");


### PR DESCRIPTION
Added the class that will resolve the default temp directory for writing cache files. 

We have to change some environment variables so I had to change the test setup. Since our tests are run in parallel, and we change the default temp directory some tests will fail since Mockito will try to run to the same temp directory. So when changing this class we need to run manually the tests in the DirectoryPathResolverTest (notice how the tests are disabled so they won't run In pipeline)