### PR TITLE
test: Fixed the tests to compile with Java 11

### DIFF
--- a/src/integrationTest/java/integration/tests/CachedConnectionTest.java
+++ b/src/integrationTest/java/integration/tests/CachedConnectionTest.java
@@ -55,12 +55,11 @@ public class CachedConnectionTest extends IntegrationTest {
             sleepForMillis(10000);
 
             // check that the connection cached was using the correct connection to the db and engine
-            String queryHistoryQueryFormat = """
-				SELECT query_text
-				FROM information_schema.engine_query_history
-				WHERE submitted_time > '%s' and status = 'STARTED_EXECUTION' and (query_text='SELECT 101;' or query_text='SELECT 103;')
-				order by submitted_time desc
-			""";
+            String queryHistoryQueryFormat =
+				"SELECT query_text " +
+				"FROM information_schema.engine_query_history " +
+				"WHERE submitted_time > '%s' and status = 'STARTED_EXECUTION' and (query_text='SELECT 101;' or query_text='SELECT 103;') " +
+				"order by submitted_time desc";
             ResultSet engineOneResultSet = connection.createStatement().executeQuery(String.format(queryHistoryQueryFormat, testStartTime));
             assertTrue(engineOneResultSet.next());
             assertEquals("SELECT 103;", engineOneResultSet.getString(1));
@@ -81,12 +80,11 @@ public class CachedConnectionTest extends IntegrationTest {
             sleepForMillis(10000);
 
             // check that the connection cached was using the correct connection to the db and engine
-            String queryHistoryQueryFormat = """
-				SELECT query_text
-				FROM information_schema.engine_query_history
-				WHERE submitted_time > '%s' and status = 'STARTED_EXECUTION' and (query_text='SELECT 102;' or query_text='SELECT 104;')
-				order by submitted_time desc
-			""";
+            String queryHistoryQueryFormat =
+				"SELECT query_text " +
+				"FROM information_schema.engine_query_history " +
+				"WHERE submitted_time > '%s' and status = 'STARTED_EXECUTION' and (query_text='SELECT 102;' or query_text='SELECT 104;') " +
+				"order by submitted_time desc";
 
             ResultSet engineTwoResultSet = connection.createStatement().executeQuery(String.format(queryHistoryQueryFormat, testStartTime));
             assertTrue(engineTwoResultSet.next());

--- a/src/integrationTest/java/integration/tests/ConnectionTest.java
+++ b/src/integrationTest/java/integration/tests/ConnectionTest.java
@@ -159,18 +159,16 @@ class ConnectionTest extends IntegrationTest {
             sleepForMillis(TimeUnit.SECONDS.toMillis(10));
 
             // there should be no select 1 statement executed
-            String selectOneQueryHistoryQueryFormat = """
-				SELECT query_text
-				FROM information_schema.engine_query_history WHERE submitted_time > '%s' and (query_text like '%%SELECT 1%%' OR query_text like '%%select 1%%');
-			""";
+            String selectOneQueryHistoryQueryFormat =
+				"SELECT query_text " +
+				"FROM information_schema.engine_query_history WHERE submitted_time > '%s' and (query_text like '%%SELECT 1%%' OR query_text like '%%select 1%%');";
             ResultSet selectQueriesRS = statement.executeQuery(String.format(selectOneQueryHistoryQueryFormat, currentUTCTime));
             assertFalse(selectQueriesRS.next());
 
             // there should be one select 222 statement executed
-            String queryHistoryQueryFormat = """
-				SELECT query_text
-				FROM information_schema.engine_query_history WHERE submitted_time > '%s' and query_text like 'SELECT 222%%' and status = 'STARTED_EXECUTION';
-			""";
+            String queryHistoryQueryFormat =
+				"SELECT query_text " +
+				"FROM information_schema.engine_query_history WHERE submitted_time > '%s' and query_text like 'SELECT 222%%' and status = 'STARTED_EXECUTION';";
 
             selectQueriesRS = statement.executeQuery(String.format(queryHistoryQueryFormat, currentUTCTime));
             assertTrue(selectQueriesRS.next());

--- a/src/integrationTest/java/integration/tests/StatementTest.java
+++ b/src/integrationTest/java/integration/tests/StatementTest.java
@@ -331,20 +331,18 @@ class StatementTest extends IntegrationTest {
 	 * @return
 	 */
 	private void assertQueryFound(Statement statement, String queryLabelValue, String afterTimestamp, String queryText) throws SQLException {
-		String queryHistoryQuery = """
-			SELECT query_text
-			FROM information_schema.engine_query_history
-			WHERE query_label = '%s' and submitted_time > '%s' and query_text = '%s';
-			""";
+		String queryHistoryQuery =
+			"SELECT query_text " +
+			"FROM information_schema.engine_query_history " +
+			"WHERE query_label = '%s' and submitted_time > '%s' and query_text = '%s'; ";
 		ResultSet resultSet = statement.executeQuery(String.format(queryHistoryQuery, queryLabelValue, afterTimestamp, queryText));
 		assertTrue(resultSet.next(), "Did not find query with the specified query label");
 	}
 
 	private String getQueryLabel(Statement statement, String afterTimestamp, String queryText) throws SQLException {
-		String queryHistoryQuery = """
-				SELECT query_label
-				FROM information_schema.engine_query_history WHERE submitted_time > '%s' and query_text = '%s';
-			""";
+		String queryHistoryQuery =
+				"SELECT query_label " +
+				"FROM information_schema.engine_query_history WHERE submitted_time > '%s' and query_text = '%s'; ";
 		ResultSet resultSet = statement.executeQuery(String.format(queryHistoryQuery, afterTimestamp, queryText));
 		assertTrue(resultSet.next(), "Did not find any query in history");
 		return resultSet.getString(1);


### PR DESCRIPTION
Background:
I was trying to add a nightly job to run the tests on 11, 17 and 21 (all the long term supported java versions) and I had realized that Java 11 the tests were not compiling. 
The """ multi string line concept was added in Java 15. So had to sent this extra review to fix the tests to run on Java 11 (since that is how we are testing the driver that it works on Java 11 by running the integration tests"