### PR TITLE
ci: FIR-45195 add nighlty job to run v1 and v2 integration tests

### DIFF
--- a/.github/workflows/integration-test-v1.yml
+++ b/.github/workflows/integration-test-v1.yml
@@ -10,6 +10,16 @@ on:
       engine:
         description: 'Engine override'
         required: false
+      java_version:
+        description: 'JRE version'
+        required: false
+        type: string
+        default: '11'
+      os_name:
+        description: 'The operating system'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
   workflow_call:
     inputs:
       database:
@@ -21,6 +31,16 @@ on:
         description: 'Engine override'
         required: false
         type: string
+      java_version:
+        description: 'JRE version'
+        required: false
+        type: string
+        default: '11'
+      os_name:
+        description: 'The operating system'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
     secrets:
       FIREBOLT_STG_USERNAME:
         required: true
@@ -29,7 +49,7 @@ on:
 
 jobs:
   run-integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.os_name }}
 
     steps:
       - name: Validate database and engine
@@ -46,7 +66,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: ${{ inputs.java_version }}
 
       - name: Setup database and engine
         id: setup
@@ -61,6 +81,7 @@ jobs:
 
       - name: Determine database name
         id: find-database-name
+        shell: bash  # use bash across all OSs
         run: |
           if ! [[ -z "${{ inputs.database }}" ]]; then
              echo "database_name=${{ inputs.database }}" >> $GITHUB_OUTPUT
@@ -70,12 +91,17 @@ jobs:
 
       - name: Determine engine name
         id: find-engine-name
+        shell: bash  # use bash across all OSs
         run: |
           if ! [[ -z "${{ inputs.engine }}" ]]; then
              echo "engine_name=${{ inputs.engine }}" >> $GITHUB_OUTPUT
           else
              echo "engine_name=${{ steps.setup.outputs.engine_name }}" >> $GITHUB_OUTPUT
           fi
+
+      - name: Grant execute permission (Unix)
+        if: runner.os != 'Windows'
+        run: chmod +x gradlew
 
       - name: Run integration tests
         run: ./gradlew integrationTest -Ddb=${{ steps.find-database-name.outputs.database_name }} -Dapi=api.staging.firebolt.io -Dpassword="${{ secrets.FIREBOLT_STG_PASSWORD }}" -Duser="${{ secrets.FIREBOLT_STG_USERNAME }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DexcludeTags=v2

--- a/.github/workflows/integration-test-v2.yml
+++ b/.github/workflows/integration-test-v2.yml
@@ -14,6 +14,16 @@ on:
         description: 'Account override'
         required: false
         type: string
+      java_version:
+        description: 'JRE version'
+        required: false
+        type: string
+        default: '11'
+      os_name:
+        description: 'The operating system'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
   workflow_call:
     inputs:
       database:
@@ -29,6 +39,16 @@ on:
         description: 'Account override'
         required: false
         type: string
+      os_name:
+        description: 'Operating system'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      java_version:
+        description: 'Java'
+        required: false
+        type: string
+        default: '11'
     secrets:
       FIREBOLT_CLIENT_ID_STG_NEW_IDN:
         required: true
@@ -37,8 +57,7 @@ on:
 
 jobs:
   run-integration-tests:
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ inputs.os_name }}
     steps:
       - name: Validate database and engine
         if: ${{ (inputs.database == '') != (inputs.engine == '') }}
@@ -49,6 +68,7 @@ jobs:
 
       - name: Resolve account
         id: set-account
+        shell: bash  # use bash across all OSs
         run: |
           if ! [[ -z "${{ inputs.account }}" ]]; then
             echo "account=${{ inputs.account }}" >> $GITHUB_OUTPUT
@@ -65,7 +85,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: ${{ inputs.java_version }}
 
       - name: Setup database and engine
         id: setup
@@ -79,6 +99,7 @@ jobs:
 
       - name: Determine database name
         id: find-database-name
+        shell: bash  # use bash across all OSs
         run: |
           if ! [[ -z "${{ inputs.database }}" ]]; then
              echo "database_name=${{ inputs.database }}" >> $GITHUB_OUTPUT
@@ -88,12 +109,17 @@ jobs:
 
       - name: Determine engine name
         id: find-engine-name
+        shell: bash  # use bash across all OSs
         run: |
           if ! [[ -z "${{ inputs.engine }}" ]]; then
              echo "engine_name=${{ inputs.engine }}" >> $GITHUB_OUTPUT
           else
              echo "engine_name=${{ steps.setup.outputs.engine_name }}" >> $GITHUB_OUTPUT
           fi
+
+      - name: Grant execute permission (Unix)
+        if: runner.os != 'Windows'
+        run: chmod +x gradlew
 
       - name: Run integration tests
         run: ./gradlew integrationTest -Ddb=${{ steps.find-database-name.outputs.database_name }} -Denv=staging -Dclient_secret="${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}" -Dclient_id="${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}" -Daccount="${{ steps.set-account.outputs.account }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DexcludeTags=v1

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -2,7 +2,29 @@ name: Run integration tests
 
 on:
   workflow_dispatch:
+    inputs:
+      java_version:
+        description: 'JRE version'
+        required: false
+        type: string
+        default: '11'
+      os_name:
+        description: 'The operating system'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
   workflow_call:
+    inputs:
+      java_version:
+        description: 'JRE version'
+        required: false
+        type: string
+        default: '11'
+      os_name:
+        description: 'The operating system'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
 
 jobs:
   run-integration-tests1:
@@ -10,10 +32,15 @@ jobs:
     secrets:
       FIREBOLT_STG_USERNAME: ${{ secrets.FIREBOLT_STG_USERNAME }}
       FIREBOLT_STG_PASSWORD: ${{ secrets.FIREBOLT_STG_PASSWORD }}
+    inputs:
+      java_version: ${{ inputs.java_version }}
+      os_name: ${{ inputs.os_name }}
 
   run-integration-tests-engine2:
     uses: ./.github/workflows/integration-test-v2.yml
     secrets:
       FIREBOLT_CLIENT_ID_STG_NEW_IDN: ${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}
       FIREBOLT_CLIENT_SECRET_STG_NEW_IDN: ${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}
-
+    inputs:
+      java_version: ${{ inputs.java_version }}
+      os_name: ${{ inputs.os_name }}

--- a/.github/workflows/nightly-v1.yaml
+++ b/.github/workflows/nightly-v1.yaml
@@ -1,0 +1,22 @@
+name: Nightly run for integration tests against v1 firebolt
+
+on:
+  schedule:
+    - cron: '45 5 * * *'        # Daily at 05:45 UTC
+  workflow_dispatch:             # Allow manual trigger
+
+jobs:
+  nightly-integration-runs-v1:
+    fail-fast: false # finish all jobs even if one fails
+    max-parallel: 2
+    matrix:
+      os: [ubuntu-latest, windows-latest, macos-latest]
+      java: [11, 17, 21]
+
+    uses: ./.github/workflows/integration-test-v1.yml
+    with:
+      os_name: ${{ matrix.os }}
+      java_version: ${{ matrix.java }}
+    secrets:
+      FIREBOLT_STG_USERNAME: ${{ secrets.FIREBOLT_STG_USERNAME }}
+      FIREBOLT_STG_PASSWORD: ${{ secrets.FIREBOLT_STG_PASSWORD }}

--- a/.github/workflows/nightly-v2.yaml
+++ b/.github/workflows/nightly-v2.yaml
@@ -1,0 +1,23 @@
+name: Nightly run for integration tests against v2 firebolt
+
+on:
+  schedule:
+    - cron: '30 3 * * *'        # Daily at 03:30 UTC
+  workflow_dispatch:             # Allow manual trigger
+
+jobs:
+  nightly-integration-runs-v2:
+    strategy:
+      fail-fast: false # finish all jobs even if one fails
+      max-parallel: 2
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        java: [11, 17, 21]
+
+    uses: ./.github/workflows/integration-test-v2.yml
+    with:
+      os_name: ${{ matrix.os }}
+      java_version: ${{ matrix.java }}
+    secrets:
+      FIREBOLT_CLIENT_ID_STG_NEW_IDN: ${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}
+      FIREBOLT_CLIENT_SECRET_STG_NEW_IDN: ${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}


### PR DESCRIPTION
I have added the nightly jobs as part of its own review (I will take it out of the PR that dealt with the default temp directory).

I have added just one combination (java 11 and ubuntu). When running multiple combinations I see that the tests are randomly failing. I need to investigate why, but we will still get some benefits of running v1 and v2 nightly on java 11 on ubuntu meanwhile. 

Few notes:
- we don't have a runner for Mac (at least when I had the Mac in the os matrix, it did not seem to run)
- I had to add shell: bash to the scripts that were doing some checking since those were failing on windows. 

Next steps. I want to have it run on Java 17 and 21 and also on windows-latest. I need to check why they are failing though. 

In order to test it I had to modify the perf git hub action and use it on my branch (See the screenshot below for v1 and v2 results of nightly runs)