### PR TITLE
test: fix the integration tests to run in parallel

### DIFF
--- a/src/integrationTest/resources/statements/async/cleanup.sql
+++ b/src/integrationTest/resources/statements/async/cleanup.sql
@@ -1,3 +1,1 @@
 DROP TABLE IF EXISTS "async_table_test" CASCADE;
-STOP ENGINE async_test_second_engine WITH TERMINATE=true;
-DROP ENGINE IF EXISTS async_test_second_engine;

--- a/src/integrationTest/resources/statements/async/ddl.sql
+++ b/src/integrationTest/resources/statements/async/ddl.sql
@@ -1,4 +1,3 @@
 CREATE TABLE IF NOT EXISTS "async_table_test" (
     id BIGINT
 );
-CREATE ENGINE IF NOT EXISTS async_test_second_engine;

--- a/src/integrationTest/resources/statements/cached-connection/cleanup.sql
+++ b/src/integrationTest/resources/statements/cached-connection/cleanup.sql
@@ -1,4 +1,1 @@
 DROP TABLE IF EXISTS statement_test CASCADE;
-STOP ENGINE cached_test_second_engine WITH TERMINATE=true;
-DROP ENGINE IF EXISTS cached_test_second_engine;
-DROP DATABASE IF EXISTS cached_test_second_db;

--- a/src/integrationTest/resources/statements/cached-connection/ddl.sql
+++ b/src/integrationTest/resources/statements/cached-connection/ddl.sql
@@ -4,7 +4,5 @@ FACT TABLE IF NOT EXISTS statement_test (
 id              LONG
 )
 PRIMARY INDEX id;
-CREATE ENGINE IF NOT EXISTS cached_test_second_engine;
-CREATE DATABASE IF NOT EXISTS cached_test_second_db;
 
 


### PR DESCRIPTION
Problem: when trying to setup nightly with different os name and java versions only one run was passing. 

When we have 3 os (windows, ubuntu, and macOS) and 3 java versions: 11, 17 and 21 the nightly job was creating 9 jobs to run integration tests. There jobs would run in parallel. 

Engine name and db names are unique for each run, but some tests were creating the same engine name in the ddl. 

Since these tests ran in parallel, the first run that succeeded would delete the engines (but at that point the ddl might have already run for the other runs so the test was assuming that the engine is present), until it was deleted. 

Create the engines in tests since we can get the engine name from the system property and append some values to it. This would guarantee that the engine names are unique across parallel runs. 