### PR TITLE
ci: FIR-45195 - fixed run for v1

### DIFF
--- a/.github/workflows/nightly-v1.yaml
+++ b/.github/workflows/nightly-v1.yaml
@@ -1,4 +1,4 @@
-name: Nightly run for integration tests against v1 firebolt
+name: Nightly integration tests v1
 
 on:
   schedule:
@@ -7,11 +7,12 @@ on:
 
 jobs:
   nightly-integration-runs-v1:
-    fail-fast: false # finish all jobs even if one fails
-    max-parallel: 2
-    matrix:
-      os: [ubuntu-latest, windows-latest, macos-latest]
-      java: [11, 17, 21]
+    strategy:
+      fail-fast: false # finish all jobs even if one fails
+      max-parallel: 2
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        java: [11, 17, 21]
 
     uses: ./.github/workflows/integration-test-v1.yml
     with:

--- a/.github/workflows/nightly-v2.yaml
+++ b/.github/workflows/nightly-v2.yaml
@@ -1,4 +1,4 @@
-name: Nightly run for integration tests against v2 firebolt
+name: Nightly integration tests v2
 
 on:
   schedule:


### PR DESCRIPTION
Missed strategy attribute on the v1 run. (https://github.com/firebolt-db/jdbc/actions/runs/14374201406)
Also shortened the names of the runs since it does show up in git hub actions and v1 and v2 were cut off (had to scroll over the job to see it)