### PR TITLE
(test) FIR-45231 - Fixed the TLS test that fails on windows

### DIFF
--- a/src/integrationTest/java/integration/tests/client/TLSTest.java
+++ b/src/integrationTest/java/integration/tests/client/TLSTest.java
@@ -6,7 +6,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
-import java.net.InetAddress;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.UUID;
@@ -25,11 +24,10 @@ public class TLSTest extends MockWebServerAwareIntegrationTest {
 		 * https://github.com/square/okhttp/blob/
 		 * 052a73d3abe536c0f04b5c7b04d35123cc2500a8/okhttp-tls/README.md
 		 */
-
-		String localhost = InetAddress.getByName("localhost").getCanonicalHostName();
-
 		// HeldCertificate represents a certificate and its private key
-		HeldCertificate localhostCertificate = new HeldCertificate.Builder().addSubjectAlternativeName(localhost)
+		HeldCertificate localhostCertificate = new HeldCertificate.Builder()
+				.addSubjectAlternativeName("127.0.0.1")
+				.addSubjectAlternativeName("localhost")
 				.build();
 
 		// HandshakeCertificates contains certificates for a TLS handshake
@@ -37,7 +35,7 @@ public class TLSTest extends MockWebServerAwareIntegrationTest {
 				.heldCertificate(localhostCertificate).addPlatformTrustedCertificates().build();
 
 		mockBackEnd.useHttps(serverCertificates.sslSocketFactory(), false);
-
+	
 		// Write the public certificate to a file that will be used by the driver for
 		// the TLS handshake
 		String path = getClass().getResource("/").getPath() + UUID.randomUUID() + ".pem";

--- a/src/integrationTest/java/integration/tests/client/TLSTest.java
+++ b/src/integrationTest/java/integration/tests/client/TLSTest.java
@@ -35,7 +35,7 @@ public class TLSTest extends MockWebServerAwareIntegrationTest {
 				.heldCertificate(localhostCertificate).addPlatformTrustedCertificates().build();
 
 		mockBackEnd.useHttps(serverCertificates.sslSocketFactory(), false);
-	
+
 		// Write the public certificate to a file that will be used by the driver for
 		// the TLS handshake
 		String path = getClass().getResource("/").getPath() + UUID.randomUUID() + ".pem";


### PR DESCRIPTION
On windows the TLS tests are failing with the following error
 javax.net.ssl.SSLPeerUnverifiedException: Hostname localhost not verified:
            certificate: sha256/yOowwRGffNWswtSf8MidkjubXGpM7kiG/amLJeRrOsw=
            DN: CN=5e8635da-3d3d-4f80-8293-1e70661934d0
            subjectAltNames: [127.0.0.1]

On Windows the resolution from localhost to 127.0.0.1 does not happen. So need to add both localhost and 127.0.0.1 as the subject alternative names for the cert.