### PR TITLE
Added the integer tests

### DIFF
--- a/src/integrationTest/java/integration/tests/resultset/IntegerTest.java
+++ b/src/integrationTest/java/integration/tests/resultset/IntegerTest.java
@@ -1,0 +1,145 @@
+package integration.tests.resultset;
+
+import integration.IntegrationTest;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Checks all the interactions with an integer type and what options are available on the result set
+ */
+public class IntegerTest extends IntegrationTest {
+
+    @BeforeAll
+    void beforeAll() {
+        executeStatementFromFile("/statements/resultset/integer/ddl.sql");
+    }
+
+    @AfterAll
+    void afterEach() {
+        executeStatementFromFile("/statements/resultset/integer/cleanup.sql");
+    }
+
+    @Test
+    void canGetResultUsingGetIntMethod() throws SQLException {
+        // create a connection on the first engine and database
+        try (Connection connection = createConnection()) {
+            ResultSet rs = connection.createStatement().executeQuery("SELECT * from integer_type_test order by id asc");
+
+            // get the first row
+            assertTrue(rs.next());
+            assertEquals(1, rs.getInt(1));
+            assertEquals(1, rs.getInt("id"));
+            assertEquals(0, rs.getInt(2));
+            assertEquals(0, rs.getInt("my_int"));
+            assertEquals(1, rs.getInt(3));
+            assertEquals(1, rs.getInt("my_int_not_null"));
+            assertEquals(0, rs.getInt(4));
+            assertEquals(0, rs.getInt("my_boolean"));
+
+            // these commented tests fail
+//            assertEquals(0, rs.getInt(5));
+//            assertEquals(0, rs.getInt("my_boolean_not_null"));
+            assertEquals(0, rs.getInt(6));
+            assertEquals(0, rs.getInt("my_bigint"));
+//            assertEquals(0, rs.getInt(7));
+//            assertEquals(0, rs.getInt("my_bigint_not_null"));
+            assertEquals(0, rs.getInt(8));
+            assertEquals(0, rs.getInt("my_real"));
+//            assertEquals(Integer.MAX_VALUE, rs.getInt(9));
+//            assertEquals(Integer.MAX_VALUE, rs.getInt("my_real_not_null"));
+            assertEquals(0, rs.getInt(10));
+            assertEquals(0, rs.getInt("my_double"));
+//            assertEquals(Integer.MAX_VALUE, rs.getInt(11));
+//            assertEquals(Integer.MAX_VALUE, rs.getInt("my_double_not_null"));
+            assertEquals(0, rs.getInt(12));
+            assertEquals(0, rs.getInt("my_text"));
+            assertEquals(12345, rs.getInt(13));
+            assertEquals(12345, rs.getInt("my_text_not_null"));
+            assertEquals(0, rs.getInt(14));
+            assertEquals(0, rs.getInt("my_numeric"));
+            assertEquals(123456789, rs.getInt(15));
+            assertEquals(123456789, rs.getInt("my_numeric_not_null"));
+
+            // get the second row
+            assertTrue(rs.next());
+            assertEquals(2, rs.getInt(1));
+            assertEquals(2, rs.getInt("id"));
+            assertEquals(101, rs.getInt(2));
+            assertEquals(101, rs.getInt("my_int"));
+            assertEquals(1, rs.getInt(3));
+            assertEquals(1, rs.getInt("my_int_not_null"));
+
+            // these commented tests fail
+//            assertEquals(1, rs.getInt(4));
+//            assertEquals(1, rs.getInt("my_boolean"));
+//            assertEquals(0, rs.getInt(5));
+//            assertEquals(0, rs.getInt("my_boolean_not_null"));
+
+//            assertEquals(0, rs.getInt(6));
+//            assertEquals(0, rs.getInt("my_bigint"));
+//            assertEquals(0, rs.getInt(7));
+//            assertEquals(0, rs.getInt("my_bigint_not_null"));
+//            assertEquals(Integer.MIN_VALUE, rs.getInt(8));
+//            assertEquals(Integer.MIN_VALUE, rs.getInt("my_real"));
+//            assertEquals(Integer.MAX_VALUE, rs.getInt(9));
+//            assertEquals(Integer.MAX_VALUE, rs.getInt("my_real_not_null"));
+//            assertEquals(Integer.MIN_VALUE, rs.getInt(10));
+//            assertEquals(Integer.MIN_VALUE, rs.getInt("my_double"));
+//            assertEquals(Integer.MAX_VALUE, rs.getInt(11));
+//            assertEquals(Integer.MAX_VALUE, rs.getInt("my_double_not_null"));
+            assertEquals(-123, rs.getInt(12));
+            assertEquals(-123, rs.getInt("my_text"));
+            assertThrows(   SQLException.class, () ->  rs.getInt(13));
+            assertThrows(   SQLException.class, () ->  rs.getInt("my_text_not_null"));
+            assertEquals(-123456789, rs.getInt(14));
+            assertEquals(-123456789, rs.getInt("my_numeric"));
+            assertEquals(123456789, rs.getInt(15));
+            assertEquals(123456789, rs.getInt("my_numeric_not_null"));
+        }
+
+    }
+
+    @Test
+    void canGetResultUsingGetObjectMethod() throws SQLException {
+        // create a connection on the first engine and database
+        try (Connection connection = createConnection()) {
+            ResultSet rs = connection.createStatement().executeQuery("SELECT * from integer_type_test order by id asc");
+
+            // get the first row
+            assertTrue(rs.next());
+            assertEquals(1, (Integer) rs.getObject(1));
+            assertEquals(1, rs.getObject(1, Integer.class));
+            assertEquals(1, (Integer) rs.getObject("id"));
+            assertEquals(1,  rs.getObject("id", Integer.class));
+            assertNull(rs.getObject(2));
+            assertNull(rs.getObject(2, Integer.class));
+            assertNull(rs.getObject("my_int"));
+            assertNull(rs.getObject("my_int", Integer.class));
+
+            // get the second row
+            assertTrue(rs.next());
+            assertEquals(2, (Integer) rs.getObject(1));
+            assertEquals(2, rs.getObject(1, Integer.class));
+            assertEquals(2, (Integer) rs.getObject("id"));
+            assertEquals(2, rs.getObject("id", Integer.class));
+            assertEquals(101, (Integer) rs.getObject(2));
+            assertEquals(101, rs.getObject(2, Integer.class));
+            assertEquals(101, (Integer) rs.getObject("my_int"));
+            assertEquals(101, rs.getObject("my_int", Integer.class));
+            assertEquals(1, (Integer) rs.getObject(3));
+            assertEquals(1, rs.getObject(3, Integer.class));
+            assertEquals(1, (Integer) rs.getObject("my_int_not_null"));
+            assertEquals(1, rs.getObject("my_int_not_null", Integer.class));
+        }
+
+    }
+}

--- a/src/integrationTest/resources/statements/resultset/integer/cleanup.sql
+++ b/src/integrationTest/resources/statements/resultset/integer/cleanup.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "integer_type_test" CASCADE;

--- a/src/integrationTest/resources/statements/resultset/integer/ddl.sql
+++ b/src/integrationTest/resources/statements/resultset/integer/ddl.sql
@@ -1,0 +1,22 @@
+DROP TABLE IF EXISTS "integer_type_test" CASCADE;
+CREATE
+FACT TABLE IF NOT EXISTS "integer_type_test" (
+    id INTEGER,
+	my_int INTEGER NULL,
+    my_int_not_null INTEGER NOT NULL,
+    my_boolean BOOLEAN NULL,
+    my_boolean_not_null BOOLEAN NOT NULL,
+    my_bigint BIGINT NULL,
+    my_bigint_not_null BIGINT NOT NULL,
+    my_real REAL NULL,
+    my_real_not_null REAL NOT NULL,
+    my_double DOUBLE NULL,
+    my_double_not_null DOUBLE NOT NULL,
+    my_text TEXT NULL,
+    my_text_not_null TEXT NOT NULL,
+    my_numeric NUMERIC NULL,
+    my_numeric_not_null NUMERIC NOT NULL
+    )
+primary index id;
+INSERT INTO integer_type_test values (1, null, 1, null, false, null, 9223372036854775807, null, 12147483647.402823, null, 12147483647.4028231234, null, '12345', null, 123456789.123456789);
+INSERT INTO integer_type_test values (2, 101, 1, true, false, -9223372036854775808, 9223372036854775807, -12147483647.99, 12147483647.123456, -12147483647.991234567, 12147483647.4028231234, '-123', 'not an int', -123456789.123456789, 123456789.123456789);


### PR DESCRIPTION
According to the 4.3 spec we should be able to get an int value from result set, using resultSet.getInt(...), if the column has the following JDBC types: TINYINT, SMALLINT, INTEGER, BIGINT, REAL, FLOAT, DOUBLE, DECIMAL, NUMERIC, BIT, BOOLEAN, CHAR, VARCHAR, LONGVARCHAR.

If the value of the column is null, it should return 0. 
If the value of the column is greater than integer (like for the case of BIGINT, FLOAT, etc) we should return Integer.MAX_VALUE or Integer.MIN_VALUE. 


Also the getObject should be used to get an integer out of a column with 2 overloaded methods. (in this case I have not added the negative tests cases).