### PR TITLE
Fix the errors seen by sql cloud tests

### DIFF
--- a/src/main/java/com/firebolt/jdbc/service/FireboltEngineVersion2Service.java
+++ b/src/main/java/com/firebolt/jdbc/service/FireboltEngineVersion2Service.java
@@ -10,13 +10,13 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 import java.util.Optional;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import static java.lang.String.format;
 
-@Slf4j
+@CustomLog
 public class FireboltEngineVersion2Service {
 
     private static final boolean DO_NOT_VALIDATE_CONNECTION_FLAG = false;


### PR DESCRIPTION
Instead of using @CustomLog I accidentally add the @Slf4j annotation which forces clients to have an LoggerFactory on the class path. 
