### PR TITLE
test FIR-45277 fix the gradle script for windows v1 integration tests

### DIFF
--- a/.github/workflows/integration-test-v1.yml
+++ b/.github/workflows/integration-test-v1.yml
@@ -104,4 +104,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run integration tests
-        run: ./gradlew integrationTest -Ddb=${{ steps.find-database-name.outputs.database_name }} -Dapi=api.staging.firebolt.io -Dpassword="${{ secrets.FIREBOLT_STG_PASSWORD }}" -Duser="${{ secrets.FIREBOLT_STG_USERNAME }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DexcludeTags=v2
+        run: ./gradlew integrationTest -Ddb="${{ steps.find-database-name.outputs.database_name }}" -Dapi="api.staging.firebolt.io" -Dpassword="${{ secrets.FIREBOLT_STG_PASSWORD }}" -Duser="${{ secrets.FIREBOLT_STG_USERNAME }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DexcludeTags="v2"

--- a/.github/workflows/integration-test-v2.yml
+++ b/.github/workflows/integration-test-v2.yml
@@ -122,4 +122,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run integration tests
-        run: ./gradlew integrationTest -Ddb=${{ steps.find-database-name.outputs.database_name }} -Denv=staging -Dclient_secret="${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}" -Dclient_id="${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}" -Daccount="${{ steps.set-account.outputs.account }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DexcludeTags=v1
+        run: ./gradlew integrationTest -Ddb="${{ steps.find-database-name.outputs.database_name }}" -Denv="staging" -Dclient_secret="${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}" -Dclient_id="${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}" -Daccount="${{ steps.set-account.outputs.account }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DexcludeTags="v1"


### PR DESCRIPTION
I have seen v1 scripts fail with the following error when running on Windows:

Task '.staging.firebolt.io' not found in root project 'firebolt-jdbc'.

On windows we need to pass in the env variables to Gradle in quotes. 

Windows run: https://github.com/firebolt-db/jdbc/actions/runs/14439806639 (it fails with  the timeout tests)
Ubuntu: https://github.com/firebolt-db/jdbc/actions/runs/14439813744
MacOs: https://github.com/firebolt-db/jdbc/actions/runs/14439817374/job/40487329231