### PR TITLE
(test) FIR-45277 pass in max series size from GitHub

### DIFF
--- a/.github/workflows/integration-test-v1.yml
+++ b/.github/workflows/integration-test-v1.yml
@@ -104,4 +104,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run integration tests
-        run: ./gradlew integrationTest -Ddb="${{ steps.find-database-name.outputs.database_name }}" -Dapi="api.staging.firebolt.io" -Dpassword="${{ secrets.FIREBOLT_STG_PASSWORD }}" -Duser="${{ secrets.FIREBOLT_STG_USERNAME }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DexcludeTags="v2"
+        run: ./gradlew integrationTest -Ddb="${{ steps.find-database-name.outputs.database_name }}" -Dapi="api.staging.firebolt.io" -Dpassword="${{ secrets.FIREBOLT_STG_PASSWORD }}" -Duser="${{ secrets.FIREBOLT_STG_USERNAME }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DexcludeTags="v2" -Dv1GenerateSeriesMaxSize="${{ vars.V1_GENERATE_SERIES_MAX_SIZE }}"

--- a/.github/workflows/integration-test-v2.yml
+++ b/.github/workflows/integration-test-v2.yml
@@ -122,4 +122,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run integration tests
-        run: ./gradlew integrationTest -Ddb="${{ steps.find-database-name.outputs.database_name }}" -Denv="staging" -Dclient_secret="${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}" -Dclient_id="${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}" -Daccount="${{ steps.set-account.outputs.account }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DexcludeTags="v1"
+        run: ./gradlew integrationTest -Ddb="${{ steps.find-database-name.outputs.database_name }}" -Denv="staging" -Dclient_secret="${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}" -Dclient_id="${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}" -Daccount="${{ steps.set-account.outputs.account }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DexcludeTags="v1" -Dv2GenerateSeriesMaxSize="${{ vars.V2_GENERATE_SERIES_MAX_SIZE }}"

--- a/src/integrationTest/java/integration/tests/TimeoutTest.java
+++ b/src/integrationTest/java/integration/tests/TimeoutTest.java
@@ -3,18 +3,19 @@ package integration.tests;
 import com.firebolt.jdbc.connection.FireboltConnection;
 import integration.EnvironmentCondition;
 import integration.IntegrationTest;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import lombok.CustomLog;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static integration.EnvironmentCondition.Attribute.databaseVersion;
 import static integration.EnvironmentCondition.Comparison.GE;
@@ -24,8 +25,24 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @CustomLog
 class TimeoutTest extends IntegrationTest {
 	private static final int MIN_TIME_SECONDS = 350;
-	private static final Map<Integer, Long> SERIES_SIZE = Map.of(1, 80000000000L, 2, 400000000000L);
+	private static final Map<Integer, Long> SERIES_SIZE = new HashMap<>();
+
 	private long startTime;
+
+	/**
+	 * From GitHub we might pass in different values rather than the default ones that we use in tests. Sometimes we see the tests finish
+	 * faster than we expect (350 seconds)
+	 */
+	@BeforeAll
+	void setupClass() {
+		long v1SeriesSize = Long.valueOf(System.getProperty("v1GenerateSeriesMaxSize", "80000000000"));
+		SERIES_SIZE.put(1, v1SeriesSize);
+		log.info("For v1 max generate series size we will use {}", v1SeriesSize);
+
+		long v2SeriesSize = Long.valueOf(System.getProperty("v2GenerateSeriesMaxSize", "500000000000"));
+		SERIES_SIZE.put(2, v2SeriesSize);
+		log.info("For v2 max generate series size we will use {}", v2SeriesSize);
+	}
 
 	@BeforeEach
 	void before() {
@@ -41,7 +58,7 @@ class TimeoutTest extends IntegrationTest {
 	}
 
 	@Test
-	@Timeout(value = 10, unit = TimeUnit.MINUTES)
+	@Timeout(value = 15, unit = TimeUnit.MINUTES)
 	@Tag("v1") // generate_series is supported on all available engine of v2
 	@Tag("slow")
 	void shouldExecuteRequestWithoutTimeoutV1() throws SQLException {
@@ -49,7 +66,7 @@ class TimeoutTest extends IntegrationTest {
 	}
 
 	@Test
-	@Timeout(value = 10, unit = TimeUnit.MINUTES)
+	@Timeout(value = 15, unit = TimeUnit.MINUTES)
 	@EnvironmentCondition(value = "3.33", attribute = databaseVersion, comparison = GE) // generate_series is supported starting from version 3.33 on v2
 	@Tag("v2")
 	@Tag("slow")


### PR DESCRIPTION
The last test that is failing on nightly (both v1 and v2) is the timeout test. 

There are 2 types of failures for this test:
1. the query finishes sooner than 350 seconds (when it does it is around 340 seconds)
2. the query times out at 10 minutes (this is the test timeout)

I have created 2 variables for the jdbc repository (see screenshot) and pass those variables to the test script for v1 and v2 respectively. Changed the TimeoutTest to check these environment variables first and if not found to use the default ones from the test (We need to make sure we can still run the test from IntelliJ). I have used 1 at the end of the value to make sure we see it being read from the variable (see second screenshot for an example from a v1 run) 

I have also increased the timeout to 15 minutes. I don't know why some runs are taking longer than 10 seconds. 