### PR TITLE
Exclude java 11 and windows from nightly runs

### DIFF
--- a/.github/workflows/nightly-v1.yaml
+++ b/.github/workflows/nightly-v1.yaml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         java: [11, 17, 21]
+        # https://packboard.atlassian.net/browse/FIR-45378 - there is a test failing on windows and java 11 related to timeouts
         exclude:
           - os: windows-latest
             java: 11

--- a/.github/workflows/nightly-v1.yaml
+++ b/.github/workflows/nightly-v1.yaml
@@ -13,7 +13,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         java: [11, 17, 21]
-
+        exclude:
+          - os: windows-latest
+            java: 11
     uses: ./.github/workflows/integration-test-v1.yml
     with:
       os_name: ${{ matrix.os }}

--- a/.github/workflows/nightly-v2.yaml
+++ b/.github/workflows/nightly-v2.yaml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         java: [11, 17, 21]
+        # https://packboard.atlassian.net/browse/FIR-45378 - there is a test failing on windows and java 11 related to timeouts
         exclude:
           - os: windows-latest
             java: 11

--- a/.github/workflows/nightly-v2.yaml
+++ b/.github/workflows/nightly-v2.yaml
@@ -13,7 +13,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         java: [11, 17, 21]
-
+        exclude:
+          - os: windows-latest
+            java: 11
     uses: ./.github/workflows/integration-test-v2.yml
     with:
       os_name: ${{ matrix.os }}


### PR DESCRIPTION
I want to get the Nightly's run to pass successfully. Now they are failing on Windows and Java 11. 
For now exclude this combination from the nightly runs. 
I have created this jira to add this combo back: https://packboard.atlassian.net/browse/FIR-45378 (I am installing Windows in a Vm and try few things there to see if changing the registry configuration fixes the issue)