### PR TITLE
(test) Defined the test tags that we can use

### DIFF
--- a/src/integrationTest/java/integration/tests/CachedConnectionTest.java
+++ b/src/integrationTest/java/integration/tests/CachedConnectionTest.java
@@ -1,5 +1,6 @@
 package integration.tests;
 
+import com.firebolt.jdbc.testutils.TestTag;
 import integration.IntegrationTest;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -48,8 +49,8 @@ public class CachedConnectionTest extends IntegrationTest {
     }
 
     @Test
-    @Tag("v2")
-    @Tag("slow")
+    @Tag(TestTag.V2)
+    @Tag(TestTag.SLOW)
     void createTwoConnections() throws SQLException {
         String testStartTime = getCurrentUTCTime();
 

--- a/src/testCommon/java/com/firebolt/jdbc/testutils/TestTag.java
+++ b/src/testCommon/java/com/firebolt/jdbc/testutils/TestTag.java
@@ -1,0 +1,19 @@
+package com.firebolt.jdbc.testutils;
+
+public class TestTag {
+
+    // tests that are run against firebolt 1.0
+    public static final String V1 = "v1";
+
+    // tests that are run against firebolt 2.0
+    public static final String V2 = "v2";
+
+    // tests that are run against firebolt core
+    public static final String FIREBOLT_CORE = "firebolt-core";
+
+    // tests that are slow
+    public static final String SLOW = "slow";
+
+    public static final String COMMON = "common";
+}
+


### PR DESCRIPTION
We will be adding the firebolt core functionality soon. We would have tests that would run against firebolt-core. 

Define a class that would have all the test tags that can be used in test. Currently we have:
-v1
-v2
-slow
-common
-firebolt-core (added now)

In the future we can add more, and we will know which tags we have by looking at this class. If we agree on this I will use Cursor to do the refactoring to use the new tags. I only changed one test to make sure everything works fine.