### PR TITLE
(feat) FIR-42058 add the support for statement_timeout

### DIFF
--- a/src/main/java/com/firebolt/jdbc/client/query/StatementClientImpl.java
+++ b/src/main/java/com/firebolt/jdbc/client/query/StatementClientImpl.java
@@ -331,7 +331,7 @@ public class StatementClientImpl extends FireboltClient implements StatementClie
 			params.put(FireboltQueryParameterKey.COMPRESS.getKey(), fireboltProperties.isCompress() ? "1" : "0");
 
 			if (queryTimeout > 0) {
-				params.put("max_execution_time", String.valueOf(queryTimeout));
+				params.put("statement_timeout", String.valueOf(queryTimeout));
 			}
 		}
 		params.put(FireboltQueryParameterKey.DATABASE.getKey(), fireboltProperties.getDatabase());

--- a/src/test/java/com/firebolt/jdbc/client/query/StatementClientImplTest.java
+++ b/src/test/java/com/firebolt/jdbc/client/query/StatementClientImplTest.java
@@ -83,7 +83,7 @@ class StatementClientImplTest {
 
 	@ParameterizedTest
 	@CsvSource({
-			"false,http://firebolt1:555/?database=db1&output_format=TabSeparatedWithNamesAndTypes&compress=1&max_execution_time=15",
+			"false,http://firebolt1:555/?database=db1&output_format=TabSeparatedWithNamesAndTypes&compress=1&statement_timeout=15",
 			"true,http://firebolt1:555/?database=db1&account_id=12345&output_format=TabSeparatedWithNamesAndTypes"
 	})
 	void shouldPostSqlQueryWithExpectedUrl(boolean systemEngine, String expectedUrl) throws SQLException, IOException {


### PR DESCRIPTION
When setting a timeout for a query we JDBC driver was sending the query param to the server as: max_execution_time. 
This was changed to statement_timeout so when a timeout is set on the statement the driver will add a query parameter as statement_timeout. 