### PR TITLE
Revert "chore: Bump version to v3.6.2"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=3.6.2
+version=3.6.1
 jdbcVersion=4.3


### PR DESCRIPTION
This reverts commit f33d39e28a92ed93d2bbb936ce9bda8fd3f8afaf.

When I triggered the release action, the integration tests and the build was running in parallel. I was expecting them to run sequentially. Got to stop it after the code upgrade. So revert the version change in git. 