### PR TITLE
Do not run the bump version unless the pre-release is succcessful

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
       FIREBOLT_CLIENT_SECRET_STG_NEW_IDN: ${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}
       
   bump-version:
+    needs: pre-release-testing
     runs-on: ubuntu-latest
     env:
       newVersion: ${{ github.event.inputs.tag_name }}
@@ -52,7 +53,6 @@ jobs:
         git push origin master
         # Push tag
         git push origin $newVersion
-
 
   build:
     needs: bump-version


### PR DESCRIPTION
This was the flow that I wanted in the release action:
- run pre-release action (build, run integration tests, run smoke test)
- if the pre-release action is successful then bump the version and release the new version. 

In reality the bump-version and pre-release actions were running in parallel. 

Added the dependent action for the bump-version (so it will run only in case pre-release-testing is successful)