### PR TITLE
Fix flaky test + enable debug for jdbc connection cache

### DIFF
--- a/src/integrationTest/resources/logback-test.xml
+++ b/src/integrationTest/resources/logback-test.xml
@@ -8,4 +8,7 @@
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>
+    <logger name="com.firebolt.jdbc.cache" level="DEBUG" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
 </configuration>


### PR DESCRIPTION
I am seeing on nightly runs the test that verifies the cache creation time failing. Fails 2/8 runs or 3/8 runs. Sometimes 0/8 runs. 

We delete the cache file and then we execute the statement to create the second db, second engine.
My theory is that the first test runs (and will execute statements against second engine which would have to start the engine). Then the tests takes about 1 minute (we do have 2 x 10 seconds waiting time). 

Start the second engine in the before all test. and also move the deletion of the test after the creation of the engine and db was executed. 