### PR TITLE
(ci) FIR-44420 part2 added the integration test workflow for core

### DIFF
--- a/.github/workflows/core-integration-test.yml
+++ b/.github/workflows/core-integration-test.yml
@@ -25,17 +25,16 @@ on:
         required: false
         type: string
         default: '4.21.0-pre.0.20250508101124.cfa76a685ee8_x86'
-      os_name:
-        description: 'Operating system'
-        required: false
-        type: string
-        default: 'ubuntu-latest'
       java_version:
         description: 'Java'
         required: false
         type: string
         default: '11'
-
+      os_name:
+        description: 'Operating system'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
 jobs:
   run-core-integration-tests:
     runs-on: ${{ inputs.os_name }}

--- a/.github/workflows/core-integration-test.yml
+++ b/.github/workflows/core-integration-test.yml
@@ -7,7 +7,6 @@ on:
         description: 'The docker image tag for the firebolt core'
         required: false
         type: string
-        default: '4.21.0-pre.0.20250508101124.cfa76a685ee8_x86'
       java_version:
         description: 'JRE version'
         required: false
@@ -24,7 +23,6 @@ on:
         description: 'The docker image tag for the firebolt core'
         required: false
         type: string
-        default: '4.21.0-pre.0.20250508101124.cfa76a685ee8_x86'
       java_version:
         description: 'Java'
         required: false
@@ -35,6 +33,8 @@ on:
         required: false
         type: string
         default: 'ubuntu-latest'
+env:
+  DEFAULT_IMAGE_TAG: ${{ vars.DEFAULT_CORE_IMAGE_TAG }}
 jobs:
   run-core-integration-tests:
     runs-on: ${{ inputs.os_name }}
@@ -73,13 +73,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
+      # if no image tag was passed in, then use the image tag from the defaults
+      - name: Set image tag
+        id: set-tag
+        run: |
+          IMAGE_TAG="${{ inputs.tag_version }}"
+          if [ -z "$IMAGE_TAG" ]; then
+            IMAGE_TAG="$DEFAULT_IMAGE_TAG"
+          fi
+          echo "tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+
       - name: Prepare docker-compose.yml
         run: |
           if [ ! -f "$DOCKER_COMPOSE_FILE" ]; then
             echo "Error: Docker compose file not found at $DOCKER_COMPOSE_FILE"
             exit 1
           fi
-          sed -i "s|\${IMAGE_TAG}|${{ inputs.tag_version }}|g" "$DOCKER_COMPOSE_FILE"
+          sed -i "s|\${IMAGE_TAG}|${{ steps.set-tag.outputs.tag }}|g" "$DOCKER_COMPOSE_FILE"
           sed -i "s|\${BASE_DIR}|${{ github.workspace }}|g" "$DOCKER_COMPOSE_FILE"
           echo "Docker compose file prepared:"
           cat "$DOCKER_COMPOSE_FILE"
@@ -108,7 +118,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run integration tests
-        run: ./gradlew integrationTest -DincludeTags="core" --info
+        run: ./gradlew integrationTest -DexcludeTags="v1,v2" --info
         env:
           GRADLE_OPTS: -Dorg.gradle.daemon=false
 

--- a/.github/workflows/core-integration-test.yml
+++ b/.github/workflows/core-integration-test.yml
@@ -1,0 +1,119 @@
+name: Core integration tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_version:
+        description: 'The docker image tag for the firebolt core'
+        required: false
+        type: string
+        default: '4.21.0-pre.0.20250508101124.cfa76a685ee8_x86'
+      java_version:
+        description: 'JRE version'
+        required: false
+        type: string
+        default: '11'
+      os_name:
+        description: 'The operating system'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+  workflow_call:
+    inputs:
+      tag_version:
+        description: 'The docker image tag for the firebolt core'
+        required: false
+        type: string
+        default: '4.21.0-pre.0.20250508101124.cfa76a685ee8_x86'
+      os_name:
+        description: 'Operating system'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      java_version:
+        description: 'Java'
+        required: false
+        type: string
+        default: '11'
+
+jobs:
+  run-core-integration-tests:
+    runs-on: ${{ inputs.os_name }}
+    env:
+      DOCKER_COMPOSE_FILE: ${{ github.workspace }}/src/integrationTest/resources/core/docker-compose.yaml
+      SERVICE_PORT: 3473
+      SERVICE_URL: http://localhost:3473
+      MAX_RETRIES: 30
+      RETRY_INTERVAL: 2
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Prepare java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: ${{ inputs.java_version }}
+          cache: 'gradle'
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Prepare docker-compose.yml
+        run: |
+          if [ ! -f "$DOCKER_COMPOSE_FILE" ]; then
+            echo "Error: Docker compose file not found at $DOCKER_COMPOSE_FILE"
+            exit 1
+          fi
+          sed -i "s|\${IMAGE_TAG}|${{ inputs.tag_version }}|g" "$DOCKER_COMPOSE_FILE"
+          sed -i "s|\${BASE_DIR}|${{ github.workspace }}|g" "$DOCKER_COMPOSE_FILE"
+          echo "Docker compose file prepared:"
+          cat "$DOCKER_COMPOSE_FILE"
+
+      - name: Start service container
+        run: |
+          docker compose -f "$DOCKER_COMPOSE_FILE" up -d
+          docker compose -f "$DOCKER_COMPOSE_FILE" ps
+
+      - name: Wait for service to be ready
+        run: |
+          for i in $(seq 1 $MAX_RETRIES); do
+            if curl --silent --fail "$SERVICE_URL" --data-binary "SELECT 1" | grep -q "1"; then
+              echo "Service is up and responding!"
+              exit 0
+            fi
+            echo "Waiting for service... ($i/$MAX_RETRIES)"
+            sleep $RETRY_INTERVAL
+          done
+          echo "Error: Service failed to start within timeout"
+          docker compose -f "$DOCKER_COMPOSE_FILE" logs
+          exit 1
+
+      - name: Grant execute permission (Unix)
+        if: runner.os != 'Windows'
+        run: chmod +x gradlew
+
+      - name: Run integration tests
+        run: ./gradlew integrationTest -DincludeTags="core" --info
+        env:
+          GRADLE_OPTS: -Dorg.gradle.daemon=false
+
+      - name: Stop container
+        if: always()
+        run: |
+          docker compose -f "$DOCKER_COMPOSE_FILE" down

--- a/.github/workflows/integration-test-v2.yml
+++ b/.github/workflows/integration-test-v2.yml
@@ -39,16 +39,16 @@ on:
         description: 'Account override'
         required: false
         type: string
-      os_name:
-        description: 'Operating system'
-        required: false
-        type: string
-        default: 'ubuntu-latest'
       java_version:
         description: 'Java'
         required: false
         type: string
         default: '11'
+      os_name:
+        description: 'Operating system'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
     secrets:
       FIREBOLT_CLIENT_ID_STG_NEW_IDN:
         required: true

--- a/src/integrationTest/resources/core/config.json
+++ b/src/integrationTest/resources/core/config.json
@@ -1,0 +1,7 @@
+{
+  "nodes": [
+    {
+      "host": "firebolt-core"
+    }
+  ]
+}

--- a/src/integrationTest/resources/core/docker-compose.yaml
+++ b/src/integrationTest/resources/core/docker-compose.yaml
@@ -1,0 +1,18 @@
+name: firebolt-core
+
+services:
+  firebolt-core:
+    image: ghcr.io/firebolt-db/firebolt-core:${IMAGE_TAG}
+    container_name: firebolt-core
+    command: --node 0
+    privileged: true
+    restart: no         # equivalent to --rm (no persistence)
+    ulimits:
+      memlock: 8589934592
+    ports:
+      - 3473:3473
+    volumes:
+      # Mount the config file into the container.
+      - ${BASE_DIR}/src/integrationTest/resources/core/config.json:/firebolt-core/config.json:ro
+      # Create an anonymous volume for Firebolt's internal database files. Not using a volume would have a performance impact.
+      - ${BASE_DIR}/firebolt-core:/firebolt-core/data


### PR DESCRIPTION
Added the workflow to run integration tests for Firebolt core. 
The workflow takes 3 parameters:
- docker image version (we can run arm or x86 docker images)
- operating system
- java version

We are starting with ubuntu, java 11 and the latest version of x86 of the firebolt core (that was released May 8th).

Once we have a stable firebolt version we could add nightly's job that would run against that version.