### PR TITLE
(test) FIR-44420 - include tests tags rather than exclude them when running integration tests

### DIFF
--- a/.github/workflows/core-integration-test.yml
+++ b/.github/workflows/core-integration-test.yml
@@ -118,7 +118,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run integration tests
-        run: ./gradlew integrationTest -DexcludeTags="v1,v2" -Ddb=integration_test_db --info
+        run: ./gradlew integrationTest -DincludeTags="core" -Ddb=integration_test_db --info
         env:
           GRADLE_OPTS: -Dorg.gradle.daemon=false
 

--- a/.github/workflows/integration-test-v1.yml
+++ b/.github/workflows/integration-test-v1.yml
@@ -115,4 +115,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run integration tests
-        run: ./gradlew integrationTest -Ddb="${{ steps.find-database-name.outputs.database_name }}" -Dapi="api.staging.firebolt.io" -Dpassword="${{ secrets.FIREBOLT_STG_PASSWORD }}" -Duser="${{ secrets.FIREBOLT_STG_USERNAME }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DexcludeTags="v2,core" -Dv1GenerateSeriesMaxSize="${{ vars.V1_GENERATE_SERIES_MAX_SIZE }}"
+        run: ./gradlew integrationTest -Ddb="${{ steps.find-database-name.outputs.database_name }}" -Dapi="api.staging.firebolt.io" -Dpassword="${{ secrets.FIREBOLT_STG_PASSWORD }}" -Duser="${{ secrets.FIREBOLT_STG_USERNAME }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DincludeTags="v1" -Dv1GenerateSeriesMaxSize="${{ vars.V1_GENERATE_SERIES_MAX_SIZE }}"

--- a/.github/workflows/integration-test-v2.yml
+++ b/.github/workflows/integration-test-v2.yml
@@ -133,4 +133,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run integration tests
-        run: ./gradlew integrationTest -Ddb="${{ steps.find-database-name.outputs.database_name }}" -Denv="staging" -Dclient_secret="${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}" -Dclient_id="${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}" -Daccount="${{ steps.set-account.outputs.account }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DexcludeTags="v1,core" -Dv2GenerateSeriesMaxSize="${{ vars.V2_GENERATE_SERIES_MAX_SIZE }}"
+        run: ./gradlew integrationTest -Ddb="${{ steps.find-database-name.outputs.database_name }}" -Denv="staging" -Dclient_secret="${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}" -Dclient_id="${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}" -Daccount="${{ steps.set-account.outputs.account }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DincludeTags="v2" -Dv2GenerateSeriesMaxSize="${{ vars.V2_GENERATE_SERIES_MAX_SIZE }}"

--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ test {
 tasks.register('integrationTest', Test) {
     description = 'Runs integration tests.'
     useJUnitPlatform() {
-        includeTags(System.getProperty("includeTags", "common").split(","))
+        includeTags(System.getProperty("includeTags", "v2").split(","))
         excludeTags(System.getProperty("excludeTags", "nothing").split(","))
     }
     reports {

--- a/src/integrationTest/java/integration/CommonIntegrationTest.java
+++ b/src/integrationTest/java/integration/CommonIntegrationTest.java
@@ -1,0 +1,13 @@
+package integration;
+
+import com.firebolt.jdbc.testutils.TestTag;
+import org.junit.jupiter.api.Tag;
+
+/**
+ * Extend this class for tests that will run against all backends: v1, v2 and core
+ */
+@Tag(TestTag.V1)
+@Tag(TestTag.V2)
+@Tag(TestTag.CORE)
+public class CommonIntegrationTest extends IntegrationTest {
+}

--- a/src/integrationTest/java/integration/GlobalSetupExtension.java
+++ b/src/integrationTest/java/integration/GlobalSetupExtension.java
@@ -65,7 +65,7 @@ public class GlobalSetupExtension implements BeforeAllCallback {
     private FireboltBackendType detectFireboltBackend() {
         Set<String> includeTags = getIncludeTags();
         if (includeTags.isEmpty()) {
-            throw new RuntimeException("Please specify which backend you want your tests to run. Use -DexcludeTags system parameter to exclude the backend (v1 or v2 or core)");
+            throw new RuntimeException("Please specify which backend you want your tests to run. Use -DincludeTags system parameter to include the backend (v1 or v2 or core)");
         }
 
         // -DincludeTags=core  -> then run against core
@@ -92,8 +92,8 @@ public class GlobalSetupExtension implements BeforeAllCallback {
      * @return
      */
     private Set<String> getIncludeTags() {
-        String excludeTags = System.getProperty("includeTags", "core");
-        String[] tags = excludeTags.split(",");
+        String includeTags = System.getProperty("includeTags", "core");
+        String[] tags = includeTags.split(",");
 
         Set<String> allSupportedTags = TestTag.getAllSupportedTags();
         return Arrays.stream(tags).filter(tag -> allSupportedTags.contains(tag))

--- a/src/integrationTest/java/integration/IntegrationTest.java
+++ b/src/integrationTest/java/integration/IntegrationTest.java
@@ -14,7 +14,6 @@ import java.util.Collections;
 import java.util.Map;
 import lombok.CustomLog;
 import lombok.SneakyThrows;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -23,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @CustomLog
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@Tag("common")
 @ExtendWith(GlobalSetupExtension.class)
 public abstract class IntegrationTest {
 

--- a/src/integrationTest/java/integration/MockWebServerAwareIntegrationTest.java
+++ b/src/integrationTest/java/integration/MockWebServerAwareIntegrationTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public abstract class MockWebServerAwareIntegrationTest extends IntegrationTest {
+public abstract class MockWebServerAwareIntegrationTest extends CommonIntegrationTest {
     protected MockWebServer mockBackEnd;
 
     @BeforeEach

--- a/src/integrationTest/java/integration/tests/AsyncQueryTest.java
+++ b/src/integrationTest/java/integration/tests/AsyncQueryTest.java
@@ -3,6 +3,7 @@ package integration.tests;
 import com.firebolt.jdbc.connection.FireboltConnection;
 import com.firebolt.jdbc.exception.FireboltException;
 import com.firebolt.jdbc.statement.FireboltStatement;
+import com.firebolt.jdbc.testutils.TestTag;
 import integration.IntegrationTest;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -71,7 +72,7 @@ class AsyncQueryTest extends IntegrationTest {
     }
 
     @Test
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void executeServerSideAsyncTest() throws SQLException {
         try (FireboltConnection connection = createConnection().unwrap(FireboltConnection.class);
              FireboltStatement statement = connection.createStatement().unwrap(FireboltStatement.class)) {
@@ -99,7 +100,7 @@ class AsyncQueryTest extends IntegrationTest {
     }
 
     @Test
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void executeServerSideAsyncTestFetchStatusWorksOnDifferentEngines() throws SQLException {
         try (FireboltConnection connection = createConnection().unwrap(FireboltConnection.class);
              FireboltStatement statement = connection.createStatement().unwrap(FireboltStatement.class)) {
@@ -128,7 +129,7 @@ class AsyncQueryTest extends IntegrationTest {
     }
 
     @Test
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void executeCancelServerSideAsyncQueryTest() throws SQLException {
         try (FireboltConnection connection = createConnection().unwrap(FireboltConnection.class);
              FireboltStatement statement = connection.createStatement().unwrap(FireboltStatement.class)) {
@@ -152,7 +153,7 @@ class AsyncQueryTest extends IntegrationTest {
     }
 
     @Test
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void executeCancelServerSideAsyncQueryWorksOnDifferentEngines() throws SQLException {
         try (FireboltConnection connection = createConnection().unwrap(FireboltConnection.class);
              FireboltStatement statement = connection.createStatement().unwrap(FireboltStatement.class)) {
@@ -181,7 +182,7 @@ class AsyncQueryTest extends IntegrationTest {
     }
 
     @Test
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void executeCancelServerSideAsyncQueryAfterQueryHasFinishedTest() throws SQLException {
         try (FireboltConnection connection = createConnection().unwrap(FireboltConnection.class);
              FireboltStatement statement = connection.createStatement().unwrap(FireboltStatement.class)) {
@@ -208,7 +209,7 @@ class AsyncQueryTest extends IntegrationTest {
     }
 
     @Test
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void executeCancelServerSideAsyncQueryWithNonExistentTokenTest() throws SQLException {
         try (FireboltConnection connection = createConnection().unwrap(FireboltConnection.class)) {
 

--- a/src/integrationTest/java/integration/tests/ConnectionTest.java
+++ b/src/integrationTest/java/integration/tests/ConnectionTest.java
@@ -37,7 +37,7 @@ class ConnectionTest extends IntegrationTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @Tag("v2")
+    @Tag(TestTag.V2)
     @EnumSource(EngineType.class)
     void connectToNotExistingDbV2(EngineType engineType) throws SQLException {
         String database = "wrong_db";
@@ -63,7 +63,7 @@ class ConnectionTest extends IntegrationTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @Tag("v1")
+    @Tag(TestTag.V1)
     @EnumSource(EngineType.class)
     void connectToNotExistingDbV1(EngineType engineType) throws SQLException {
         String database = "wrong_db";
@@ -88,7 +88,7 @@ class ConnectionTest extends IntegrationTest {
      * @throws SQLException if connection fails
      */
     @Test
-    @Tag("v2")
+    @Tag(TestTag.V2)
     @EnvironmentCondition(value = "2", comparison = EnvironmentCondition.Comparison.LT)
     void connectToWrongDbNotAttachedToEngine() throws SQLException {
         ConnectionInfo params = integration.ConnectionInfo.getInstance();
@@ -110,7 +110,7 @@ class ConnectionTest extends IntegrationTest {
             "true, false",
             "true, true"
     })
-    @Tag("v1")
+    @Tag(TestTag.V1)
     void successfulConnectV1(boolean useDatabase, boolean useEngine) throws SQLException {
         successfulConnect(useDatabase, useEngine);
     }
@@ -119,7 +119,7 @@ class ConnectionTest extends IntegrationTest {
     @CsvSource({
             "false, false",
     })
-    @Tag("v1")
+    @Tag(TestTag.V1)
     void unsuccessfulConnectV1(boolean useDatabase, boolean useEngine) throws SQLException {
         unsuccessfulConnect(useDatabase, useEngine);
     }
@@ -128,7 +128,7 @@ class ConnectionTest extends IntegrationTest {
     @CsvSource({
             "false, true", // can connect but cannot execute select
     })
-    @Tag("v1")
+    @Tag(TestTag.V1)
     void successfulConnectUnsuccessfulSelectV1(boolean useDatabase, boolean useEngine) throws SQLException {
         ConnectionInfo params = integration.ConnectionInfo.getInstance();
         String url = getJdbcUrl(params, useDatabase, useEngine);
@@ -146,7 +146,7 @@ class ConnectionTest extends IntegrationTest {
             "true, true"
 
     })
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void successfulConnect(boolean useDatabase, boolean useEngine) throws SQLException {
         ConnectionInfo params = integration.ConnectionInfo.getInstance();
         String url = getJdbcUrl(params, useDatabase, useEngine);
@@ -159,7 +159,7 @@ class ConnectionTest extends IntegrationTest {
     }
 
     @Test
-    @Tag("v2")
+    @Tag(TestTag.V2)
     @Tag("slow")
     void successfulConnectWithoutStartingTheEngine() throws SQLException {
         String currentUTCTime = getCurrentUTCTime();
@@ -198,7 +198,7 @@ class ConnectionTest extends IntegrationTest {
     }
 
     @Test
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void validatesOnSystemEngineIfParameterProvided() throws SQLException {
         try (Connection systemConnection = createConnection(null)) {
             String engineName = integration.ConnectionInfo.getInstance().getEngine() + "_validate_test";
@@ -230,7 +230,7 @@ class ConnectionTest extends IntegrationTest {
     }
 
     @Test
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void preparedStatementBatchesWorkIfMergeParameterProvided() throws SQLException {
         String engineName = integration.ConnectionInfo.getInstance().getEngine();
         String queryLabel = "test_merge_batches_" + System.currentTimeMillis();
@@ -274,7 +274,7 @@ class ConnectionTest extends IntegrationTest {
     }
 
     @Test
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void networkPolicyBlockedServiceAccountThrowsError() throws SQLException {
         try (Connection connection = createConnection();
              Statement statement = connection.createStatement()) {

--- a/src/integrationTest/java/integration/tests/ConnectionTest.java
+++ b/src/integrationTest/java/integration/tests/ConnectionTest.java
@@ -160,7 +160,7 @@ class ConnectionTest extends IntegrationTest {
 
     @Test
     @Tag(TestTag.V2)
-    @Tag("slow")
+    @Tag(TestTag.SLOW)
     void successfulConnectWithoutStartingTheEngine() throws SQLException {
         String currentUTCTime = getCurrentUTCTime();
 

--- a/src/integrationTest/java/integration/tests/DatabaseMetaDataTest.java
+++ b/src/integrationTest/java/integration/tests/DatabaseMetaDataTest.java
@@ -1,7 +1,7 @@
 package integration.tests;
 
+import integration.CommonIntegrationTest;
 import integration.ConnectionInfo;
-import integration.IntegrationTest;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -64,7 +64,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class DatabaseMetaDataTest extends IntegrationTest {
+class DatabaseMetaDataTest extends CommonIntegrationTest {
 
 	@BeforeAll
 	void beforeAll() {

--- a/src/integrationTest/java/integration/tests/MissingDataTest.java
+++ b/src/integrationTest/java/integration/tests/MissingDataTest.java
@@ -1,14 +1,14 @@
 package integration.tests;
 
+import com.firebolt.jdbc.testutils.TestTag;
 import integration.ConnectionInfo;
 import integration.IntegrationTest;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class MissingDataTest extends IntegrationTest {
     @Test
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void missingAccount() throws SQLException {
         ConnectionInfo current = integration.ConnectionInfo.getInstance();
         try (Connection good = DriverManager.getConnection(current.toJdbcUrl(), current.getPrincipal(), current.getSecret())) {

--- a/src/integrationTest/java/integration/tests/NullableValuesTest.java
+++ b/src/integrationTest/java/integration/tests/NullableValuesTest.java
@@ -1,6 +1,6 @@
 package integration.tests;
 
-import integration.IntegrationTest;
+import integration.CommonIntegrationTest;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class NullableValuesTest extends IntegrationTest {
+class NullableValuesTest extends CommonIntegrationTest {
     @BeforeEach
     void beforeEach() {
         executeStatementFromFile("/statements/nullable-types/ddl.sql");

--- a/src/integrationTest/java/integration/tests/NumericTypesTest.java
+++ b/src/integrationTest/java/integration/tests/NumericTypesTest.java
@@ -1,6 +1,6 @@
 package integration.tests;
 
-import integration.IntegrationTest;
+import integration.CommonIntegrationTest;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class NumericTypesTest extends IntegrationTest {
+class NumericTypesTest extends CommonIntegrationTest {
     @Test
     void shouldHaveCorrectInfo() throws SQLException {
         try (Connection connection = createConnection(null);

--- a/src/integrationTest/java/integration/tests/PreparedStatementArrayTest.java
+++ b/src/integrationTest/java/integration/tests/PreparedStatementArrayTest.java
@@ -2,7 +2,7 @@ package integration.tests;
 
 import com.firebolt.jdbc.type.FireboltDataType;
 import com.firebolt.jdbc.type.array.FireboltArray;
-import integration.IntegrationTest;
+import integration.CommonIntegrationTest;
 import java.sql.Array;
 import java.sql.Connection;
 import java.sql.JDBCType;
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 @CustomLog
-class PreparedStatementArrayTest extends IntegrationTest {
+class PreparedStatementArrayTest extends CommonIntegrationTest {
 	enum PreparedStatementValueSetter {
 		ARRAY {
 			Object create(FireboltDataType type, Object data) {

--- a/src/integrationTest/java/integration/tests/PreparedStatementFbNumericTest.java
+++ b/src/integrationTest/java/integration/tests/PreparedStatementFbNumericTest.java
@@ -6,21 +6,10 @@ import com.firebolt.jdbc.QueryResult;
 import com.firebolt.jdbc.exception.FireboltException;
 import com.firebolt.jdbc.resultset.FireboltResultSet;
 import com.firebolt.jdbc.testutils.AssertionUtil;
+import com.firebolt.jdbc.testutils.TestTag;
 import com.firebolt.jdbc.type.FireboltDataType;
 import integration.ConnectionInfo;
 import integration.IntegrationTest;
-import lombok.Builder;
-import lombok.CustomLog;
-import lombok.EqualsAndHashCode;
-import lombok.Value;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.sql.Connection;
@@ -37,6 +26,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import lombok.Builder;
+import lombok.CustomLog;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static java.sql.Statement.SUCCESS_NO_INFO;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -60,7 +60,8 @@ class PreparedStatementFbNumericTest extends IntegrationTest {
 	}
 
 	@Test
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	void shouldInsertRecordsInBatch() throws SQLException {
 		Car car1 = Car.builder().make("Ford").sales(150).build();
 		Car car2 = Car.builder().make("Tesla").sales(300).build();
@@ -115,7 +116,8 @@ class PreparedStatementFbNumericTest extends IntegrationTest {
 
 	@ParameterizedTest(name = "{0}")
 	@MethodSource("numericTypes")
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	<T> void shouldInsertRecordsUsingDifferentNumericTypes(String name, CheckedVoidTriFunction<PreparedStatement, Integer, Integer> setter, CheckedBiFunction<ResultSet, Integer, T> getter) throws SQLException {
 		Car car = Car.builder().make("Tesla").sales(42).build();
 		try (Connection connection = getConnectionWithFbNumericQueryParameters()) {
@@ -140,7 +142,8 @@ class PreparedStatementFbNumericTest extends IntegrationTest {
 	}
 
 	@Test
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	void shouldReplaceParamMarkers() throws SQLException {
 		String insertSql = "INSERT INTO prepared_statement_test(sales, make) VALUES /* Some comment ? */ -- other comment ? \n  ($1,$2)";
 		try (Connection connection = getConnectionWithFbNumericQueryParameters()) {
@@ -173,7 +176,8 @@ class PreparedStatementFbNumericTest extends IntegrationTest {
 	}
 
 	@Test
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	void shouldReplaceParamMarkersInMultistatementStatement() throws SQLException {
 		String insertSql = "INSERT INTO prepared_statement_test(sales, make) VALUES /* Some comment ? */ -- other comment ? \n  ($1,$2);"
 				+ "INSERT INTO prepared_statement_test(sales, make) VALUES ($3,$4)";
@@ -214,7 +218,8 @@ class PreparedStatementFbNumericTest extends IntegrationTest {
 	}
 
 	@Test
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	void shouldFailSQLInjectionAttempt() throws SQLException {
 		String insertSql = "INSERT INTO prepared_statement_test(sales, make) VALUES /* Some comment ? */ -- other comment ? \n  ($1,$2)";
 		try (Connection connection = getConnectionWithFbNumericQueryParameters()) {
@@ -239,7 +244,8 @@ class PreparedStatementFbNumericTest extends IntegrationTest {
 	}
 
 	@Test
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	void shouldInsertAndSelectDateTime() throws SQLException {
 		Car car1 = Car.builder().make("Ford").sales(12345).ts(new Timestamp(2)).d(new Date(3)).build();
 		try (Connection connection = getConnectionWithFbNumericQueryParameters()) {
@@ -268,7 +274,8 @@ class PreparedStatementFbNumericTest extends IntegrationTest {
 
 
 	@Test
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	void shouldInsertAndSelectGeography() throws SQLException {
 
 		executeStatementFromFile("/statements/prepared-statement/ddl_2_0.sql");
@@ -295,7 +302,8 @@ class PreparedStatementFbNumericTest extends IntegrationTest {
 	}
 
 	@Test
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	void shouldInsertAndSelectStruct() throws SQLException {
 		Car car1 = Car.builder().make("Ford").sales(12345).ts(new Timestamp(2)).d(new Date(3)).build();
 
@@ -329,7 +337,8 @@ class PreparedStatementFbNumericTest extends IntegrationTest {
 	}
 
 	@Test
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	void shouldInsertAndSelectComplexStruct() throws SQLException {
 		Car car1 = Car.builder().ts(new Timestamp(2)).d(new Date(3)).tags(new String[] { "fast", "sleek" }).build();
 
@@ -377,7 +386,8 @@ class PreparedStatementFbNumericTest extends IntegrationTest {
 	}
 
 	@Test
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	void shouldInsertAndRetrieveUrl() throws SQLException, MalformedURLException {
 		Car tesla = Car.builder().make("Tesla").url(new URL("https://www.tesla.com/")).sales(300).build();
 		Car nothing = Car.builder().sales(0).build();
@@ -408,7 +418,8 @@ class PreparedStatementFbNumericTest extends IntegrationTest {
 	}
 
 	@Test
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	void shouldFetchSpecialCharacters() throws SQLException {
 		try (Connection connection = getConnectionWithFbNumericQueryParameters()) {
 			try (PreparedStatement statement = connection
@@ -429,7 +440,8 @@ class PreparedStatementFbNumericTest extends IntegrationTest {
 	}
 
 	@Test
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	void shouldSetParametersWithRandomIndex() throws SQLException {
 		try (Connection connection = getConnectionWithFbNumericQueryParameters()) {
 			try (PreparedStatement statement = connection
@@ -450,7 +462,8 @@ class PreparedStatementFbNumericTest extends IntegrationTest {
 	}
 
 	@Test
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	void shouldSetParametersWithRepeatingValues() throws SQLException {
 		try (Connection connection = getConnectionWithFbNumericQueryParameters()) {
 			try (PreparedStatement statement = connection
@@ -469,7 +482,8 @@ class PreparedStatementFbNumericTest extends IntegrationTest {
 	}
 
 	@Test
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	void shouldNotFailWhenParametersNotPresentAreSet() throws SQLException {
 		try (Connection connection = getConnectionWithFbNumericQueryParameters()) {
 			try (PreparedStatement statement = connection
@@ -489,7 +503,8 @@ class PreparedStatementFbNumericTest extends IntegrationTest {
 	}
 
 	@Test
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	void shouldResetTheParameterIndex() throws SQLException {
 		try (Connection connection = getConnectionWithFbNumericQueryParameters()) {
 			try (PreparedStatement statement = connection
@@ -509,7 +524,8 @@ class PreparedStatementFbNumericTest extends IntegrationTest {
 	}
 
 	@Test
-	@Tag("v2")
+	@Tag(TestTag.V2)
+//	@Tag(TestTag.CORE) - this fails, against core. Will be fixed in next review
 	void shouldFailWhenParameterNotProvided() throws SQLException {
 		try (Connection connection = getConnectionWithFbNumericQueryParameters()) {
 			try (PreparedStatement statement = connection

--- a/src/integrationTest/java/integration/tests/PreparedStatementTest.java
+++ b/src/integrationTest/java/integration/tests/PreparedStatementTest.java
@@ -5,6 +5,7 @@ import com.firebolt.jdbc.CheckedVoidTriFunction;
 import com.firebolt.jdbc.QueryResult;
 import com.firebolt.jdbc.resultset.FireboltResultSet;
 import com.firebolt.jdbc.testutils.AssertionUtil;
+import com.firebolt.jdbc.testutils.TestTag;
 import com.firebolt.jdbc.type.FireboltDataType;
 import integration.ConnectionInfo;
 import integration.IntegrationTest;
@@ -68,6 +69,9 @@ class PreparedStatementTest extends IntegrationTest {
 		executeStatementFromFile("/statements/prepared-statement/cleanup.sql");
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldInsertRecordsInBatch() throws SQLException {
 		Car car1 = Car.builder().make("Ford").sales(150).build();
@@ -93,9 +97,9 @@ class PreparedStatementTest extends IntegrationTest {
 			QueryResult queryResult = createExpectedResult(expectedRows);
 
 			try (Statement statement = connection.createStatement();
-					ResultSet rs = statement
-							.executeQuery("SELECT sales, make FROM prepared_statement_test ORDER BY make");
-					ResultSet expectedRs = FireboltResultSet.of(queryResult)) {
+				 ResultSet rs = statement
+						 .executeQuery("SELECT sales, make FROM prepared_statement_test ORDER BY make");
+				 ResultSet expectedRs = FireboltResultSet.of(queryResult)) {
 				AssertionUtil.assertResultSetEquality(expectedRs, rs);
 			}
 		}
@@ -136,6 +140,9 @@ class PreparedStatementTest extends IntegrationTest {
 
 	@ParameterizedTest(name = "{0}")
 	@MethodSource("numericTypes")
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	<T> void shouldInsertRecordsUsingDifferentNumericTypes(String name, CheckedVoidTriFunction<PreparedStatement, Integer, Integer> setter, CheckedBiFunction<ResultSet, Integer, T> getter) throws SQLException {
 		Car car = Car.builder().make("Tesla").sales(42).build();
 		try (Connection connection = createConnection()) {
@@ -159,6 +166,9 @@ class PreparedStatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldReplaceParamMarkers() throws SQLException {
 		String insertSql = "INSERT INTO prepared_statement_test(sales, make) VALUES /* Some comment ? */ -- other comment ? \n  (?,?)";
@@ -187,6 +197,9 @@ class PreparedStatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldParReplaceParamMarkersInMultistatementStatement() throws SQLException {
 		String insertSql = "INSERT INTO prepared_statement_test(sales, make) VALUES /* Some comment ? */ -- other comment ? \n  (?,?);"
@@ -227,6 +240,9 @@ class PreparedStatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldFailSQLInjectionAttempt() throws SQLException {
 		String insertSql = "INSERT INTO prepared_statement_test(sales, make) VALUES /* Some comment ? */ -- other comment ? \n  (?,?)";
@@ -251,6 +267,9 @@ class PreparedStatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldInsertAndSelectByteArray() throws SQLException {
 		Car car1 = Car.builder().make("Ford").sales(12345).signature("Henry Ford".getBytes()).build();
@@ -282,6 +301,9 @@ class PreparedStatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldInsertAndSelectBlobClob() throws SQLException, IOException {
 		Car car1 = Car.builder().make("Ford").sales(12345).signature("Henry Ford".getBytes()).build();
@@ -329,6 +351,9 @@ class PreparedStatementTest extends IntegrationTest {
 		return clob;
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldInsertAndSelectStreams() throws SQLException, IOException {
 		Car car1 = Car.builder().make("Ford").sales(12345).signature("Henry Ford".getBytes()).build();
@@ -364,6 +389,9 @@ class PreparedStatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldInsertAndSelectDateTime() throws SQLException {
 		Car car1 = Car.builder().make("Ford").sales(12345).ts(new Timestamp(2)).d(new Date(3)).build();
@@ -393,7 +421,8 @@ class PreparedStatementTest extends IntegrationTest {
 
 
 	@Test
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	void shouldInsertAndSelectGeography() throws SQLException {
 
 		executeStatementFromFile("/statements/prepared-statement/ddl_2_0.sql");
@@ -420,7 +449,8 @@ class PreparedStatementTest extends IntegrationTest {
 	}
 
 	@Test
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	void shouldInsertAndSelectStruct() throws SQLException {
 		Car car1 = Car.builder().make("Ford").sales(12345).ts(new Timestamp(2)).d(new Date(3)).build();
 
@@ -455,6 +485,9 @@ class PreparedStatementTest extends IntegrationTest {
 	@ParameterizedTest
 	@DefaultTimeZone("UTC")
 	@MethodSource("dateTypes")
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	void shouldFetchTimestampAndDate(Object timestampOrLocalDateTime, Object dateOrLocalDate, boolean addTargetSqlType) throws SQLException {
 		String expectedTimestamp = "2019-07-31 11:15:13";
 		String expectedDate = "2019-07-31";
@@ -485,7 +518,8 @@ class PreparedStatementTest extends IntegrationTest {
 
 
 	@Test
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	void shouldInsertAndSelectComplexStruct() throws SQLException {
 		Car car1 = Car.builder().ts(new Timestamp(2)).d(new Date(3)).tags(new String[] { "fast", "sleek" }).build();
 
@@ -532,6 +566,9 @@ class PreparedStatementTest extends IntegrationTest {
 
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldInsertAndRetrieveUrl() throws SQLException, MalformedURLException {
 		Car tesla = Car.builder().make("Tesla").url(new URL("https://www.tesla.com/")).sales(300).build();
@@ -562,6 +599,9 @@ class PreparedStatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldFetchSpecialCharacters() throws SQLException, MalformedURLException {
 		try (Connection connection = createConnection()) {
@@ -582,6 +622,9 @@ class PreparedStatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldFetchBoolean() throws SQLException {
 		try (Connection connection = createConnection()) {
@@ -606,6 +649,9 @@ class PreparedStatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Disabled
 	@ParameterizedTest
 	@MethodSource("com.firebolt.jdbc.testutils.TestFixtures#booleanTypes")

--- a/src/integrationTest/java/integration/tests/SpecialValuesTest.java
+++ b/src/integrationTest/java/integration/tests/SpecialValuesTest.java
@@ -1,17 +1,17 @@
 package integration.tests;
 
+import com.firebolt.jdbc.testutils.TestTag;
 import integration.IntegrationTest;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import lombok.CustomLog;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -43,114 +43,129 @@ public class SpecialValuesTest extends IntegrationTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"select 'inf'::float", "select '+inf'::float"})
-    @Tag("v1")
+    @Tag(TestTag.V1)
     void infFloatUserEngine(String query) throws SQLException {
         specialSelect(userConnection, query, Float.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Float.POSITIVE_INFINITY);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"select 'inf'::real", "select '+inf'::real"})
+    @Tag(TestTag.V2)
+    @Tag(TestTag.V1)
+    @Tag(TestTag.CORE)
     void infRealUserEngine(String query) throws SQLException {
         specialSelect(userConnection, query, Float.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Float.POSITIVE_INFINITY);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"select 'inf'::real", "select '+inf'::real"})
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void infRealSystemEngine(String query) throws SQLException {
         specialSelect(userConnection, query, Float.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Float.POSITIVE_INFINITY);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"select 'inf'::float", "select '+inf'::float"})
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void infFloatAsDoubleUserEngine(String query) throws SQLException {
         specialSelect(userConnection, query, Float.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"select 'inf'::float", "select '+inf'::float"})
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void infFloatAsDoubleSystemEngine(String query) throws SQLException {
         specialSelect(systemConnection, query, Float.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"select 'inf'::double", "select '+inf'::double"})
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void infDoubleSystemEngine(String query) throws SQLException {
         specialSelect(systemConnection, query, Float.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"select 'inf'::double", "select '+inf'::double"})
+    @Tag(TestTag.V2)
+    @Tag(TestTag.V1)
+    @Tag(TestTag.CORE)
     void infDoubleUserEngine(String query) throws SQLException {
         specialSelect(userConnection, query, Float.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"select '-inf'::float"})
-    @Tag("v1")
+    @Tag(TestTag.V1)
     void minusInfFloatUserEngine(String query) throws SQLException {
         specialSelect(userConnection, query, Float.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"select '-inf'::float"})
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void minusInfFloatAsDoubleUserEngine(String query) throws SQLException {
         specialSelect(userConnection, query, Float.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"select '-inf'::real"})
+    @Tag(TestTag.V2)
+    @Tag(TestTag.V1)
+    @Tag(TestTag.CORE)
     void minusInfRealUserEngine(String query) throws SQLException {
         specialSelect(userConnection, query, Float.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"select '-inf'::real"})
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void minusInfRealSystemEngine(String query) throws SQLException {
         specialSelect(systemConnection, query, Float.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"select '-inf'::float"})
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void minusInfFloatAsDoubleSystemEngine(String query) throws SQLException {
         specialSelect(systemConnection, query, Float.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"select '-inf'::double"})
+    @Tag(TestTag.V2)
+    @Tag(TestTag.V1)
+    @Tag(TestTag.CORE)
     void minusInfDoubleUserEngine(String query) throws SQLException {
         specialSelect(userConnection, query, Float.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"select 'nan'::float", "select '+nan'::float", "select '-nan'::float"})
-    @Tag("v1")
+    @Tag(TestTag.V1)
     void nanFloatUserEngine(String query) throws SQLException {
         specialSelect(userConnection, query, Float.NaN, Double.NaN, Float.NaN);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"select 'nan'::real", "select '+nan'::real", "select '-nan'::real"})
+    @Tag(TestTag.V2)
+    @Tag(TestTag.V1)
+    @Tag(TestTag.CORE)
     void nanRealUserEngine(String query) throws SQLException {
         specialSelect(userConnection, query, Float.NaN, Double.NaN, Float.NaN);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"select 'nan'::real", "select '+nan'::real", "select '-nan'::real"})
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void nanRealSystemEngine(String query) throws SQLException {
         specialSelect(systemConnection, query, Float.NaN, Double.NaN, Float.NaN);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"select 'nan'::float", "select '+nan'::float", "select '-nan'::float"})
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void nanFloatAsDoubleUserEngine(String query) throws SQLException {
         specialSelect(userConnection, query, Float.NaN, Double.NaN, Double.NaN);
     }
@@ -159,7 +174,7 @@ public class SpecialValuesTest extends IntegrationTest {
     @ValueSource(strings = {
             "select 'nan'::double", "select '+nan'::double", "select '-nan'::double"
     })
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void nanDoubleSystemEngine(String query) throws SQLException {
         specialSelect(systemConnection, query, Float.NaN, Double.NaN, Double.NaN);
     }
@@ -168,13 +183,16 @@ public class SpecialValuesTest extends IntegrationTest {
     @ValueSource(strings = {
             "select 'nan'::float", "select '+nan'::float", "select '-nan'::float",
     })
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void nanFloatAsDoubleSystemEngine(String query) throws SQLException {
         specialSelect(systemConnection, query, Float.NaN, Double.NaN, Double.NaN);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"select 'nan'::double", "select '+nan'::double", "select '-nan'::double"})
+    @Tag(TestTag.V2)
+    @Tag(TestTag.V1)
+    @Tag(TestTag.CORE)
     void nanDoubleUserEngine(String query) throws SQLException {
         specialSelect(userConnection, query, Float.NaN, Double.NaN, Double.NaN);
     }

--- a/src/integrationTest/java/integration/tests/StatementCancelTest.java
+++ b/src/integrationTest/java/integration/tests/StatementCancelTest.java
@@ -3,20 +3,20 @@ package integration.tests;
 import com.firebolt.jdbc.exception.ExceptionType;
 import com.firebolt.jdbc.exception.FireboltException;
 import com.firebolt.jdbc.statement.FireboltStatement;
+import com.firebolt.jdbc.testutils.TestTag;
 import integration.EnvironmentCondition;
 import integration.IntegrationTest;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
 import lombok.CustomLog;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.concurrent.TimeUnit;
 
 import static integration.EnvironmentCondition.Attribute.databaseVersion;
 import static integration.EnvironmentCondition.Comparison.GE;
@@ -37,8 +37,8 @@ class StatementCancelTest extends IntegrationTest {
 
 	@Test
 	@Timeout(value = 2, unit = TimeUnit.MINUTES)
-	@Tag("v1") // generate_series is supported on all available engine of v2
-	@Tag("slow")
+	@Tag(TestTag.V1) // generate_series is supported on all available engine of v2
+	@Tag(TestTag.SLOW)
 	void shouldCancelQueryV1() throws SQLException, InterruptedException {
 		shouldCancelQuery();
 	}
@@ -46,9 +46,10 @@ class StatementCancelTest extends IntegrationTest {
 	@Test
 	@Timeout(value = 10, unit = TimeUnit.MINUTES)
 	@EnvironmentCondition(value = "3.33", attribute = databaseVersion, comparison = GE) // generate_series is supported starting from version 3.33 on v2
-	@Tag("v2")
-	@Tag("slow")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.SLOW)
 	void shouldCancelQueryV2() throws SQLException, InterruptedException {
+
 		shouldCancelQuery();
 	}
 

--- a/src/integrationTest/java/integration/tests/StatementTest.java
+++ b/src/integrationTest/java/integration/tests/StatementTest.java
@@ -60,6 +60,9 @@ class StatementTest extends IntegrationTest {
 		executeStatementFromFile("/statements/statement/cleanup.sql");
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldSelect1() throws SQLException {
 		try (Connection connection = createConnection();
@@ -72,6 +75,8 @@ class StatementTest extends IntegrationTest {
 
 	@Test
 	@EnabledIfSystemProperty(named = "engine", matches = ".+")
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
 	void shouldSelect1WithEngine() throws SQLException {
 		try (Connection connection = createConnection(System.getProperty("engine")); Statement statement = connection.createStatement()) {
 			statement.executeQuery("SELECT 1;");
@@ -79,6 +84,9 @@ class StatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldSelect1WithQueryTimeout() throws SQLException {
 		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
@@ -88,6 +96,9 @@ class StatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldReuseStatementWhenNotCloseOnCompletion() throws SQLException {
 		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
@@ -96,6 +107,9 @@ class StatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldThrowExceptionWhenTryingToReuseStatementClosedOnCompletion() throws SQLException {
 		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
@@ -106,7 +120,8 @@ class StatementTest extends IntegrationTest {
 		}
 	}
 
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldThrowExceptionWhenExecutingWrongQuery() throws SQLException {
 		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
@@ -115,7 +130,7 @@ class StatementTest extends IntegrationTest {
 		}
 	}
 
-	@Tag("v1")
+	@Tag(TestTag.V1)
 	@Test
 	void shouldThrowExceptionWhenExecutingWrongQueryV1() throws SQLException {
 		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
@@ -127,7 +142,8 @@ class StatementTest extends IntegrationTest {
 	}
 
 	@Test
-	@Tag("v2")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@EnvironmentCondition(value = "4.2.0", attribute = databaseVersion, comparison = EnvironmentCondition.Comparison.GE)
 	void shouldThrowExceptionWhenExecutingWrongQueryWithJsonError() throws SQLException {
 		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
@@ -140,6 +156,9 @@ class StatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldReturnTrueWhenExecutingAStatementThatReturnsAResultSet() throws SQLException {
 		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
@@ -147,6 +166,9 @@ class StatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldReturnTrueWhenExecutingMultiStatementWithFirstStatementReturningAResultSet() throws SQLException {
 		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
@@ -154,6 +176,9 @@ class StatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldReturnFalseWhenExecutingMultiStatementWithFirstStatementNotReturningAResultSet() throws SQLException {
 		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
@@ -161,6 +186,9 @@ class StatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldReturnLimitedNumberOfLines() throws SQLException {
 		try (Connection connection = createConnection(); Statement insert = connection.createStatement()) {
@@ -191,6 +219,9 @@ class StatementTest extends IntegrationTest {
 		return result;
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldExecuteBatch() throws SQLException {
 		int size = 10;
@@ -202,6 +233,9 @@ class StatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldThrowExceptionWhenTryingToExecuteQueryThatWouldReturnMultipleResultSets() throws SQLException {
 		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
@@ -209,6 +243,9 @@ class StatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldGetMultipleResultSets() throws SQLException {
 		String sql = "  --Getting Multiple RS;\nSELECT 1; /* comment 1 ; ; ; */\n\n --Another comment ; \n  -- ; \n SELECT 2; /* comment 2 */";
@@ -228,6 +265,9 @@ class StatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldNotCloseStatementWithCloseOnCompletionIfItHasMoreResults() throws SQLException {
 		String sql = "SELECT 1;SELECT 2;";
@@ -247,6 +287,9 @@ class StatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void shouldGetBooleans() throws SQLException {
 		try (Connection connection = createConnection()) {
@@ -286,8 +329,9 @@ class StatementTest extends IntegrationTest {
 	}
 
 	@Test
-	@Tag("v2")
-	@Tag("slow")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
+	@Tag(TestTag.SLOW)
 	void canSetQueryLabelMultipleTimes() throws SQLException {
 		try (Connection connection = createConnection()) {
 			try (Statement statement = connection.createStatement()) {
@@ -317,8 +361,9 @@ class StatementTest extends IntegrationTest {
 	}
 
 	@Test
-	@Tag("v2")
-	@Tag("slow")
+	@Tag(TestTag.V2)
+//	@Tag(TestTag.CORE) - this fails, against core. Will be fixed in next review
+	@Tag(TestTag.SLOW)
 	void willUseRandomQueryLabelIfNoneExplicitlySet() throws SQLException {
 		try (Connection connection = createConnection()) {
 			try (Statement statement = connection.createStatement()) {
@@ -363,6 +408,9 @@ class StatementTest extends IntegrationTest {
 	 * Connect to DB using {@code advanced_mode} sent in JDBC URL and set {@code force_pgdate_timestampntz} that requires advanced mode.
 	 * @throws SQLException if connection fails
 	 */
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void successfulSettingOfPropertyThatRequiresAdvancedModeConfiguredWhenConnectionIsCreated() throws SQLException {
 		try (Connection connection = createConnection(ConnectionInfo.getInstance().getEngine(), Map.of("advanced_mode", "1"))) {
@@ -374,6 +422,9 @@ class StatementTest extends IntegrationTest {
 	 * Connect to DB without {@code advanced_mode}. Then set {@code advanced_mode=1} and {@code force_pgdate_timestampntz} that requires advanced mode.
 	 * @throws SQLException if connection fails
 	 */
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void successfulSettingOfPropertyThatRequiresAdvancedModePreviouslySetAtRuntime() throws SQLException {
 		try (Connection connection = createConnection()) {
@@ -387,8 +438,8 @@ class StatementTest extends IntegrationTest {
 	 * Not yet implemented in Core (https://packboard.atlassian.net/browse/FIR-46022) so only run for v2 and v2
 	 */
 	@Test
-	@Tag(TestTag.V1)
 	@Tag(TestTag.V2)
+//	@Tag(TestTag.CORE) - this fails, against core. Will be fixed in next review
 	void failedSettingPropertyThatRequiresAdvancedModeThatWasNotSet() throws SQLException {
 		try (Connection connection = createConnection()) {
 			assertFailingSet(connection, "force_pgdate_timestampntz");
@@ -401,8 +452,8 @@ class StatementTest extends IntegrationTest {
 	 * Not yet implemented in Core (https://packboard.atlassian.net/browse/FIR-46022) so only run for v2 and v2
 	 */
 	@Test
-	@Tag(TestTag.V1)
 	@Tag(TestTag.V2)
+//	@Tag(TestTag.CORE) - this fails, against core. Will be fixed in next review
 	void failedSettingPropertyThatRequiresAdvancedModeThatWasUnset() throws SQLException {
 		try (Connection connection = createConnection(ConnectionInfo.getInstance().getEngine(), Map.of("advanced_mode", "1"))) {
 			setParam(connection, "advanced_mode", "0");
@@ -434,6 +485,9 @@ class StatementTest extends IntegrationTest {
 			"-- SELECT 1",
 			"/* {\"app\": \"dbt\", \"dbt_version\": \"0.20.0\", \"profile_name\": \"jaffle_shop\", \"target_name\": \"fb_app\", \"connection_name\": \"macro_stage_external_sources\"} */"
 	})
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	void empty(String sql) throws SQLException {
 		try (Connection connection = createConnection()) {
 			assertFalse(connection.createStatement().execute(sql));
@@ -445,6 +499,9 @@ class StatementTest extends IntegrationTest {
 	 * @throws SQLException if something is going wrong
 	 * see com.firebolt.jdbc.metadata.FireboltDatabaseMetadataTest#nullSorting
 	 */
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void nullSortOrder() throws SQLException {
 		try (Connection connection = createConnection();
@@ -464,6 +521,9 @@ class StatementTest extends IntegrationTest {
 	 * see com.firebolt.jdbc.metadata.FireboltDatabaseMetadataTest#identifiersCase
 	 * see com.firebolt.jdbc.metadata.FireboltDatabaseMetadataTest#quotedIdentifiersCase
 	 */
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@ParameterizedTest
 	@CsvSource(value = {
 			"select 1 as lower, 2 as UPPER, 3 AS MiXeD;lower,upper,mixed",
@@ -489,6 +549,9 @@ class StatementTest extends IntegrationTest {
 	 * see com.firebolt.jdbc.metadata.FireboltDatabaseMetadataTest#identifiersCase
 	 * see com.firebolt.jdbc.metadata.FireboltDatabaseMetadataTest#quotedIdentifiersCase
 	 */
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@ParameterizedTest
 	@CsvSource(value = {
 			"CREATE FACT TABLE Case_Test (x long);case_test;Case_Test;case_test",
@@ -519,6 +582,9 @@ class StatementTest extends IntegrationTest {
 	 * @param query the SQL statement that should fail
 	 * @throws SQLException if something is going wrong
 	 */
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@ParameterizedTest
 	@ValueSource(strings = {
 			"SELECT CONVERT(varchar, 3.14)" //com.firebolt.jdbc.metadata.FireboltDatabaseMetadataTest#supportsConvert
@@ -529,6 +595,9 @@ class StatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void caseInsensitiveGetter() throws SQLException {
 		try (Connection connection = createConnection(); Statement statement = connection.createStatement();
@@ -544,6 +613,9 @@ class StatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@ParameterizedTest
 	@ValueSource(ints = {1, 3, 5, 50})
 	void maxFieldSize(int maxFieldSize) throws SQLException {
@@ -554,6 +626,9 @@ class StatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V1)
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@ParameterizedTest
 	@ValueSource(ints = {0, -1, 100})
 	void unlimitedMaxFieldSize(int maxFieldSize) throws SQLException {

--- a/src/integrationTest/java/integration/tests/SystemEngineDatabaseMetaDataTest.java
+++ b/src/integrationTest/java/integration/tests/SystemEngineDatabaseMetaDataTest.java
@@ -60,19 +60,19 @@ public class SystemEngineDatabaseMetaDataTest extends IntegrationTest {
         assertEquals(List.of(List.of("information_schema", database)), getRows(DatabaseMetaData::getSchemas));
     }
 
-	@Test
+    @Test
     @Tag(TestTag.V2)
-	void getCatalogs() throws SQLException {
-		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
+    void getCatalogs() throws SQLException {
+        try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
             String database = integration.ConnectionInfo.getInstance().getDatabase();
             try {
-				statement.executeUpdate(format("CREATE DATABASE %s_get_catalogs", database));
-				assertTrue(getRows(DatabaseMetaData::getCatalogs).contains(List.of(database)));
-				assertTrue(getRows(DatabaseMetaData::getCatalogs).contains(List.of(database)));
-			} finally {
-				statement.executeUpdate(format("DROP DATABASE IF EXISTS %s_get_catalogs", database));
-			}
-		}
+                statement.executeUpdate(format("CREATE DATABASE %s_get_catalogs", database));
+                assertTrue(getRows(DatabaseMetaData::getCatalogs).contains(List.of(database)));
+                assertTrue(getRows(DatabaseMetaData::getCatalogs).contains(List.of(database)));
+            } finally {
+                statement.executeUpdate(format("DROP DATABASE IF EXISTS %s_get_catalogs", database));
+            }
+        }
     }
 
     @ParameterizedTest

--- a/src/integrationTest/java/integration/tests/SystemEngineDatabaseMetaDataTest.java
+++ b/src/integrationTest/java/integration/tests/SystemEngineDatabaseMetaDataTest.java
@@ -1,6 +1,7 @@
 package integration.tests;
 
 import com.firebolt.jdbc.CheckedFunction;
+import com.firebolt.jdbc.testutils.TestTag;
 import integration.IntegrationTest;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -44,6 +45,8 @@ public class SystemEngineDatabaseMetaDataTest extends IntegrationTest {
         connection.close();
     }
 
+    @Tag(TestTag.V1)
+    @Tag(TestTag.V2)
     @Test
     void readOnly() throws SQLException {
         assertFalse(connection.isReadOnly());
@@ -51,14 +54,14 @@ public class SystemEngineDatabaseMetaDataTest extends IntegrationTest {
     }
 
     @Test
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void getSchemas() throws SQLException {
         String database = integration.ConnectionInfo.getInstance().getDatabase();
         assertEquals(List.of(List.of("information_schema", database)), getRows(DatabaseMetaData::getSchemas));
     }
 
 	@Test
-	@Tag("v2")
+    @Tag(TestTag.V2)
 	void getCatalogs() throws SQLException {
 		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
             String database = integration.ConnectionInfo.getInstance().getDatabase();
@@ -88,7 +91,7 @@ public class SystemEngineDatabaseMetaDataTest extends IntegrationTest {
             "wrong_catalog,,",
             "wrong_catalog,%form%,",
     })
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void getSchemasInformationSchema(String catalog, String schemaPattern, String expectedSchemasStr) throws SQLException {
         String database = integration.ConnectionInfo.getInstance().getDatabase();
         String cat = catalog == null ? null :  catalog.replace("{database}", database);
@@ -139,7 +142,7 @@ public class SystemEngineDatabaseMetaDataTest extends IntegrationTest {
             ",,,TABLE,,",
             "wrong_catalog,%form%,%in%,VIEW,,engines",
     })
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void getTables(String catalog, String schemaPattern, String tableNamePattern, String types, String requiredTableName, String forbiddenTableName) throws SQLException {
         String database = integration.ConnectionInfo.getInstance().getDatabase();
         String requiredCatalog = catalog == null ? null : catalog.replace("{database}", database);
@@ -204,7 +207,7 @@ public class SystemEngineDatabaseMetaDataTest extends IntegrationTest {
             ",,,does-not-exist,,information_schema.columns.column_name",
             "wrong_catalog,%form%,%in%,type,,information_schema.engines.type",
     })
-    @Tag("v2")
+    @Tag(TestTag.V2)
     void getColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern, String requiredColumn, String forbiddenColumn) throws SQLException {
         String database = integration.ConnectionInfo.getInstance().getDatabase();
         String requiredCatalog = catalog == null ? null : catalog.replace("{database}", database);

--- a/src/integrationTest/java/integration/tests/TimeoutTest.java
+++ b/src/integrationTest/java/integration/tests/TimeoutTest.java
@@ -1,6 +1,7 @@
 package integration.tests;
 
 import com.firebolt.jdbc.connection.FireboltConnection;
+import com.firebolt.jdbc.testutils.TestTag;
 import integration.EnvironmentCondition;
 import integration.IntegrationTest;
 import java.sql.Connection;
@@ -59,8 +60,8 @@ class TimeoutTest extends IntegrationTest {
 
 	@Test
 	@Timeout(value = 15, unit = TimeUnit.MINUTES)
-	@Tag("v1") // generate_series is supported on all available engine of v2
-	@Tag("slow")
+	@Tag(TestTag.V1)
+	@Tag(TestTag.SLOW)
 	void shouldExecuteRequestWithoutTimeoutV1() throws SQLException {
 		shouldExecuteRequestWithoutTimeout();
 	}
@@ -68,8 +69,9 @@ class TimeoutTest extends IntegrationTest {
 	@Test
 	@Timeout(value = 15, unit = TimeUnit.MINUTES)
 	@EnvironmentCondition(value = "3.33", attribute = databaseVersion, comparison = GE) // generate_series is supported starting from version 3.33 on v2
-	@Tag("v2")
-	@Tag("slow")
+	@Tag(TestTag.V2)
+//	@Tag(TestTag.CORE) - this fails, against core. Will be fixed in next review
+	@Tag(TestTag.SLOW)
 	void shouldExecuteRequestWithoutTimeoutV2() throws SQLException {
 		shouldExecuteRequestWithoutTimeout();
 	}

--- a/src/integrationTest/java/integration/tests/TimestampTest.java
+++ b/src/integrationTest/java/integration/tests/TimestampTest.java
@@ -1,7 +1,7 @@
 package integration.tests;
 
 import com.firebolt.jdbc.testutils.AssertionUtil;
-import integration.IntegrationTest;
+import integration.CommonIntegrationTest;
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
 import java.io.IOException;
 import java.sql.Connection;
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @CustomLog
 @DefaultTimeZone("UTC")
-class TimestampTest extends IntegrationTest {
+class TimestampTest extends CommonIntegrationTest {
 	private static final TimeZone UTC_TZ = TimeZone.getTimeZone("UTC");
 	private static final Calendar EST_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone("EST"));
 	private static final Calendar ECT_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone("ECT"));

--- a/src/testCommon/java/com/firebolt/jdbc/testutils/TestTag.java
+++ b/src/testCommon/java/com/firebolt/jdbc/testutils/TestTag.java
@@ -16,10 +16,8 @@ public class TestTag {
     // tests that are slow
     public static final String SLOW = "slow";
 
-    public static final String COMMON = "common";
-
     public static Set<String> getAllSupportedTags() {
-        return Set.of(V1, V2, CORE, SLOW, COMMON);
+        return Set.of(V1, V2, CORE, SLOW);
     }
 }
 


### PR DESCRIPTION
Before firebolt core we had 2 backend: v1 and v2 and we were controlling the tagging of the tests using the following tags:
- common (would run against both backends)
- v1 - would run only on v1
- v2 - would run only on v2

We used to run the integration tests for v1 by excluding the test with v2: -DexcludeTags=v2

This approach does not work when we add the core backend as well since now we have 7 possibilities instead of 3: 
- test should run against all backends
- test should run against just one backend (v1, v2 or core)
- tests should run on combination of backends (v1 and v2 but not on core, v1 and core but not v2, v2 and core but not v1)

Changed the tests to always specify the backends that the test should run against. Introduced another abstract class CommonIntegrationTest that can be extended when the tests in that class should run against all backends. 

Changed the command line for each integration tests to include the backend that it needs to run agasint: -DincludeTags=core (would run the tests annotated with core)

NOTE: there are 5 tests that when run against core are failing. I will address the fixes for them in the next PR