### PR TITLE
(test) FIR-44420 fixed the failing tests against 4.22

### DIFF
--- a/src/integrationTest/java/integration/tests/PreparedStatementTest.java
+++ b/src/integrationTest/java/integration/tests/PreparedStatementTest.java
@@ -554,7 +554,6 @@ class PreparedStatementTest extends IntegrationTest {
 		}
 	}
 
-
 	@Test
 	@Tag(TestTag.V2)
 	@Tag(TestTag.CORE)

--- a/src/integrationTest/resources/statements/prepared-statement-struct/ddl.sql
+++ b/src/integrationTest/resources/statements/prepared-statement-struct/ddl.sql
@@ -1,6 +1,6 @@
 SET advanced_mode=1;
 SET enable_create_table_v2=true;
-SET enable_struct=true;
+SET enable_struct_syntax=true;
 SET prevent_create_on_information_schema=true;
 SET enable_create_table_with_struct_type=true;
 DROP TABLE IF EXISTS test_struct;


### PR DESCRIPTION
Core team has release the fixes in 4.22. Before it was 4.21.

They have fixed some issues with the setting of parameters not being recognized. 

There are few other changes as well:
- force_pgdate_timestampntz is not supported any more for core (actually it is not doing anything for cloud as well)
- time_zone setting is not supported for core but the new property is timezone. This is the same for cloud but it seems that on cloud both work. 
- error messages for an unknown parameter is different if the query is ran against user engine or system engine. So changed the tests to reflect that. For core it will be similar to cloud when running on user engine. 


