### PR TITLE
(fix) FIR-46390 - allow using of OffsetDateTime with prepared statements

### DIFF
--- a/src/integrationTest/java/integration/tests/PreparedStatementFbNumericTest.java
+++ b/src/integrationTest/java/integration/tests/PreparedStatementFbNumericTest.java
@@ -325,9 +325,9 @@ class PreparedStatementFbNumericTest extends IntegrationTest {
 							.executeQuery("SELECT prepared_statement_test FROM prepared_statement_test")) {
 				rs.next();
 				assertEquals(FireboltDataType.STRUCT.name().toLowerCase()
-								+ "(make text, sales long, ts timestamp null, d date null, signature bytea null, url text null)",
+								+ "(make text, sales long, ts timestamp null, d date null, signature bytea null, url text null, tsz timestamptz null)",
 						rs.getMetaData().getColumnTypeName(1).toLowerCase());
-				String expectedJson = String.format("{\"make\":\"%s\",\"sales\":\"%d\",\"ts\":\"%s\",\"d\":\"%s\",\"signature\":null,\"url\":null}",
+				String expectedJson = String.format("{\"make\":\"%s\",\"sales\":\"%d\",\"ts\":\"%s\",\"d\":\"%s\",\"signature\":null,\"url\":null,\"tsz\":null}",
 						car1.getMake(), car1.getSales(), car1.getTs().toString(), car1.getD().toString());
 				assertEquals(expectedJson, rs.getString(1));
 			}

--- a/src/integrationTest/java/integration/tests/PreparedStatementTest.java
+++ b/src/integrationTest/java/integration/tests/PreparedStatementTest.java
@@ -27,6 +27,8 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -471,9 +473,9 @@ class PreparedStatementTest extends IntegrationTest {
 							.executeQuery("SELECT prepared_statement_test FROM prepared_statement_test")) {
 				rs.next();
 				assertEquals(FireboltDataType.STRUCT.name().toLowerCase()
-								+ "(make text, sales long, ts timestamp null, d date null, signature bytea null, url text null)",
+								+ "(make text, sales long, ts timestamp null, d date null, signature bytea null, url text null, tsz timestamptz null)",
 						rs.getMetaData().getColumnTypeName(1).toLowerCase());
-				String expectedJson = String.format("{\"make\":\"%s\",\"sales\":\"%d\",\"ts\":\"%s\",\"d\":\"%s\",\"signature\":null,\"url\":null}",
+				String expectedJson = String.format("{\"make\":\"%s\",\"sales\":\"%d\",\"ts\":\"%s\",\"d\":\"%s\",\"signature\":null,\"url\":null,\"tsz\":null}",
 						car1.getMake(), car1.getSales(), car1.getTs().toString(), car1.getD().toString());
 				assertEquals(expectedJson, rs.getString(1));
 			}
@@ -510,6 +512,42 @@ class PreparedStatementTest extends IntegrationTest {
 				rs.next();
 				assertEquals(expectedTimestamp, rs.getString(1));
 				assertEquals(expectedDate, rs.getString(2));
+			}
+		} finally {
+			executeStatementFromFile("/statements/prepared-statement/cleanup.sql");
+		}
+	}
+
+	@Test
+	@DefaultTimeZone("UTC")
+	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
+	void shouldFetchTimestampWithTimezone() throws SQLException {
+		String expectedUtcTimestamp = "2019-07-31 10:15:13.123456+00";
+
+		// will use this local date "2019-07-31 11:15:13" for Europe/Berlin timezone
+		// also firebolt only keeps microseconds and offset date time supports nanoseconds so in order to set: 123456 microseconds we need to use 123456000
+		OffsetDateTime timestampWithTimezone = OffsetDateTime.of(
+				2019, 7, 31,     // year, month, day
+				11, 15, 13, 123456000,    // hour, minute, second, nanosecond
+				ZoneOffset.of("+01:00")   // for Europe/Berlin
+		);
+
+		try (Connection connection = createConnection()) {
+			try (PreparedStatement statement = connection
+					.prepareStatement("INSERT INTO prepared_statement_test (ts, d, make, sales, tsz) VALUES (NULL,NULL, '', 0,?)")) {
+				statement.setObject(1, timestampWithTimezone);
+				statement.executeUpdate();
+			}
+
+			try (Statement statement = connection.createStatement();
+				 ResultSet rs = statement
+						 .executeQuery("SELECT tsz FROM prepared_statement_test")) {
+				rs.next();
+				OffsetDateTime offsetDateTime = rs.getObject(1, OffsetDateTime.class);
+				assertEquals(timestampWithTimezone.toInstant(), offsetDateTime.toInstant()); // they should represent the same instant in time
+
+				assertEquals(expectedUtcTimestamp, rs.getString(1)); // string value will be in UTC timezone
 			}
 		} finally {
 			executeStatementFromFile("/statements/prepared-statement/cleanup.sql");

--- a/src/integrationTest/resources/statements/prepared-statement/ddl.sql
+++ b/src/integrationTest/resources/statements/prepared-statement/ddl.sql
@@ -6,6 +6,7 @@ FACT TABLE IF NOT EXISTS prepared_statement_test (
 	ts              timestamp NULL,
 	d               date NULL,
     signature       bytea null,
-    url             STRING null
+    url             STRING null,
+    tsz             timestamptz NULL
 )
 PRIMARY INDEX make;

--- a/src/main/java/com/firebolt/jdbc/type/JavaTypeToFireboltSQLString.java
+++ b/src/main/java/com/firebolt/jdbc/type/JavaTypeToFireboltSQLString.java
@@ -6,7 +6,6 @@ import com.firebolt.jdbc.CheckedSupplier;
 import com.firebolt.jdbc.exception.FireboltException;
 import com.firebolt.jdbc.type.array.SqlArrayUtil;
 import com.firebolt.jdbc.type.date.SqlDateUtil;
-
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Array;
@@ -19,6 +18,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -48,10 +48,10 @@ public enum JavaTypeToFireboltSQLString {
 	LOCAL_DATE(LocalDate.class, date -> SqlDateUtil.transformFromLocalDateToSQLStringFunction.apply((LocalDate) date)),
 	TIMESTAMP(Timestamp.class, time -> SqlDateUtil.transformFromTimestampToSQLStringFunction.apply((Timestamp) time), (ts, tz) -> SqlDateUtil.transformFromTimestampWithTimezoneToSQLStringFunction.apply((Timestamp) ts, toTimeZone(tz))),
 	LOCAL_DATE_TIME(LocalDateTime.class, time -> SqlDateUtil.transformFromLocalDateTimeToSQLStringFunction.apply((LocalDateTime) time)),
+	OFFSET_DATE_TIME(OffsetDateTime.class, offsetDateTime -> SqlDateUtil.transformFromOffsetDateTimeToSQLStringFunction.apply((OffsetDateTime) offsetDateTime)),
 	BIG_DECIMAL(BigDecimal.class, value -> value == null ? BaseType.NULL_VALUE : ((BigDecimal) value).toPlainString()),
 	ARRAY(Array.class, SqlArrayUtil::arrayToString),
-	BYTE_ARRAY(byte[].class, value -> ofNullable(byteArrayToHexString((byte[])value, true)).map(x  -> format("E'%s'::BYTEA", x)).orElse(null)),
-	;
+	BYTE_ARRAY(byte[].class, value -> ofNullable(byteArrayToHexString((byte[])value, true)).map(x  -> format("E'%s'::BYTEA", x)).orElse(null));
 
 	private static final List<Entry<String, String>> legacyCharacterToEscapedCharacterPairs = List.of(
 			Map.entry("\0", "\\0"), Map.entry("\\", "\\\\"), Map.entry("'", "''"));

--- a/src/main/java/com/firebolt/jdbc/type/date/SqlDateUtil.java
+++ b/src/main/java/com/firebolt/jdbc/type/date/SqlDateUtil.java
@@ -1,9 +1,6 @@
 package com.firebolt.jdbc.type.date;
 
 import com.firebolt.jdbc.CheckedBiFunction;
-import lombok.CustomLog;
-import lombok.experimental.UtilityClass;
-
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -17,6 +14,8 @@ import java.time.temporal.ChronoField;
 import java.util.TimeZone;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import lombok.CustomLog;
+import lombok.experimental.UtilityClass;
 
 @UtilityClass
 @CustomLog
@@ -31,6 +30,8 @@ public class SqlDateUtil {
 
 	public static final Function<LocalDateTime, String> transformFromLocalDateTimeToSQLStringFunction = value -> String
 			.format("'%s'", dateTimeFormatter.format(value));
+	public static final Function<OffsetDateTime, String> transformFromOffsetDateTimeToSQLStringFunction = offsetDateTime ->
+			String.format("'%s'", offsetDateTime.toString());
 	public static final Function<Timestamp, String> transformFromTimestampToSQLStringFunction = value ->
 			transformFromLocalDateTimeToSQLStringFunction.apply(value.toLocalDateTime());
 	public static final BiFunction<Timestamp, TimeZone, String> transformFromTimestampWithTimezoneToStringFunction =


### PR DESCRIPTION
Debezium integration passes OffsetDateTime to our JDBC handler and we are not able to process the request successfully. 

Added at timestamptz to the table so we can test the insertion and fetching of the timestamp when OffsetDateTime is used, so we had to also change some other tests as well that were checking the table metadata. 