### PR TITLE
(fix) FIR-44420 fixed sending the compress query param

### DIFF
--- a/src/main/java/com/firebolt/jdbc/client/query/FireboltCloudV2QueryParameterProvider.java
+++ b/src/main/java/com/firebolt/jdbc/client/query/FireboltCloudV2QueryParameterProvider.java
@@ -22,8 +22,6 @@ public class FireboltCloudV2QueryParameterProvider extends AbstractQueryParamete
         }
 
         addQueryParameterIfNeeded(params, statementInfoWrapper.getPreparedStatementParameters());
-        addCompress(params, fireboltProperties.isCompress());
-        addQueryTimeoutIfNeeded(params, queryTimeout);
         addDatabaseIfNeeded(params, fireboltProperties.getDatabase());
         addServerAsyncIfNeeded(params, isServerAsync);
 
@@ -32,6 +30,8 @@ public class FireboltCloudV2QueryParameterProvider extends AbstractQueryParamete
             addAccountIdIfNeeded(params, fireboltProperties.getAccountId());
             addEngineIfNeeded(params, fireboltProperties.getEngine());
             addQueryLabel(params, fireboltProperties, statementInfoWrapper);
+            addCompress(params, fireboltProperties.isCompress());
+            addQueryTimeoutIfNeeded(params, queryTimeout);
         }
 
         return params;

--- a/src/test/java/com/firebolt/jdbc/client/query/FireboltCloudV2QueryParameterProviderTest.java
+++ b/src/test/java/com/firebolt/jdbc/client/query/FireboltCloudV2QueryParameterProviderTest.java
@@ -79,17 +79,15 @@ class FireboltCloudV2QueryParameterProviderTest extends AbstractQueryParameterPr
     }
 
     @Test
-    void shouldNotAddEngineAndAccountIdForSystemEngine() {
+    void shouldNotAddEngineAndAccountIdCompressOrQueryTimeoutForSystemEngine() {
         mockSystemEngine();
-        mockIsCompressInProperties(false);
         mockDatabaseInProperties(null);
         mockPreparedStatements(null);
         mockStatementType(StatementType.QUERY);
 
-        Map<String, String> queryParams = fireboltCloudV2QueryParameterProvider.getQueryParams(mockFireboltProperties, mockStatementInfoWrapper, NO_QUERY_TIMEOUT, IS_NOT_SERVER_ASYNC);
+        Map<String, String> queryParams = fireboltCloudV2QueryParameterProvider.getQueryParams(mockFireboltProperties, mockStatementInfoWrapper, QUERY_TIMEOUT, IS_NOT_SERVER_ASYNC);
 
-        assertEquals(3, queryParams.size());
-        assertEquals("0", queryParams.get(FireboltQueryParameterKey.COMPRESS.getKey()));
+        assertEquals(2, queryParams.size());
         assertEquals(FireboltCloudV2QueryParameterProvider.TAB_SEPARATED_WITH_NAMES_AND_TYPES_FORMAT, queryParams.get(FireboltQueryParameterKey.OUTPUT_FORMAT.getKey()));
         assertEquals("value1", queryParams.get("key1"));
     }


### PR DESCRIPTION
While checking another issue for compress for core I have realized that I had a small mistake where we would include the compress and query headers for v2 even when talking to system engine. It is fine for v1, but was wrong for v2. 

This was the code that I had originally refactored:

private Map<String, String> getAllParameters(FireboltProperties fireboltProperties,
		
	StatementInfoWrapper statementInfoWrapper, boolean systemEngine, int queryTimeout, boolean isServerAsync) {

		boolean isLocalDb = PropertyUtil.isLocalDb(fireboltProperties);

		Map<String, String> params = new HashMap<>(fireboltProperties.getAdditionalProperties());

		getResponseFormatParameter(statementInfoWrapper.getType() == StatementType.QUERY, isLocalDb)
				.ifPresent(format -> params.put(format.getKey(), format.getValue()));

		if (StringUtils.isNotBlank(statementInfoWrapper.getPreparedStatementParameters())) {
			params.put(FireboltQueryParameterKey.QUERY_PARAMETERS.getKey(), statementInfoWrapper.getPreparedStatementParameters());
		}

		String accountId = fireboltProperties.getAccountId();
		if (systemEngine) {
			if (accountId != null && connection.getInfraVersion() < 2) {
				// if infra version >= 2 we should add account_id only if it was supplied by system URL returned from server.
				// In this case it will be in additionalProperties anyway.
				params.put(FireboltQueryParameterKey.ACCOUNT_ID.getKey(), accountId);
			}
		} else {
			if (connection.getInfraVersion() >= 2) {
				String engine = fireboltProperties.getEngine();
				if (accountId != null) {
					params.put(FireboltQueryParameterKey.ACCOUNT_ID.getKey(), accountId);
				}
				if (engine != null) {
					params.put(FireboltQueryParameterKey.ENGINE.getKey(), engine);
				}

				params.put(FireboltQueryParameterKey.QUERY_LABEL.getKey(), QueryLabelResolver.getQueryLabel(fireboltProperties, statementInfoWrapper)); //QUERY_LABEL
			}
			params.put(FireboltQueryParameterKey.COMPRESS.getKey(), fireboltProperties.isCompress() ? "1" : "0");

			if (queryTimeout > 0) {
				params.put("max_execution_time", String.valueOf(queryTimeout));
			}
		}
		params.put(FireboltQueryParameterKey.DATABASE.getKey(), fireboltProperties.getDatabase());
		if (isServerAsync) {
			params.put(FireboltQueryParameterKey.ASYNC.getKey(), "true");
		}

		return params;
	}

If you see the compress and query timeout were added of non system engine (the else part), but in the refactoring we were always adding those 2 headers. 