### PR TITLE
(test) FIR-44420 add test for connecting to wrong database

### DIFF
--- a/src/integrationTest/java/integration/tests/ConnectionTest.java
+++ b/src/integrationTest/java/integration/tests/ConnectionTest.java
@@ -83,6 +83,25 @@ class ConnectionTest extends IntegrationTest {
         }
     }
 
+    @Test
+    @Tag(TestTag.CORE)
+    void connectToNotExistingDbInCore() throws SQLException {
+        // when backend will fix their code this test will start failing
+        String database = "wrong_db";
+        createConnectionWithOptions(ConnectionOptions.builder().database(database).build());
+    }
+
+    @Test
+    @Tag(TestTag.CORE)
+    void doNotHaveToSpecifyTheDatabaseWhenConnectingToCore() throws SQLException {
+        try (Connection fireboltConnection = createConnectionWithOptions(ConnectionOptions.builder().database(null).build()); Statement statement = fireboltConnection.createStatement()) {
+            ResultSet resultSet = statement.executeQuery("SELECT 1");
+            assertTrue(resultSet.next());
+            assertEquals("1", resultSet.getString(1));
+            assertFalse(resultSet.next());
+        }
+    }
+
     /**
      * Try to connect to existing DB and existing engine but the engine is attached to another DB.
      * @throws SQLException if connection fails

--- a/src/integrationTest/java/integration/tests/StatementTest.java
+++ b/src/integrationTest/java/integration/tests/StatementTest.java
@@ -704,6 +704,24 @@ class StatementTest extends IntegrationTest {
 		}
 	}
 
+	@Tag(TestTag.V2)
+	@Test
+	void cannotChangeToDatabaseThatDoesNotExist() throws SQLException {
+		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
+			SQLException exception = assertThrows(SQLException.class, () -> statement.executeUpdate("USE DATABASE \"a_db_that_does_not_exist\";"));
+			assertTrue(exception.getMessage().contains("Database 'a_db_that_does_not_exist' does not exist or not authorized."));
+		}
+	}
+
+	@Tag(TestTag.CORE)
+	@Test
+	void cannotChangeToDatabaseThatDoesNotExistForCore() throws SQLException {
+		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
+			// this test will start failing when the backend will fix their issue, just add the Tag(TestTag.CORE) annotation to the method cannotChangeToDatabaseThatDoesNotExist
+			statement.executeUpdate("USE DATABASE \"a_db_that_does_not_exist\";");
+		}
+	}
+
 	private Collection<String> readValues(Statement statement, String query, int columnIndex) throws SQLException {
 		List<String> values = new ArrayList<>();
 		try (ResultSet rs = statement.executeQuery(query)) {


### PR DESCRIPTION
Added tests for Core to fail when:
- database in the connection url does not exist
- executing a statement that would change the db (USE database "....") to a database name that does not exist. 


These tests are currently passing but will fail once the backend fixes the issue. 