### PR TITLE
(test) FIR-44420 fixed tests against 4.23

### DIFF
--- a/src/integrationTest/java/integration/GlobalSetupExtension.java
+++ b/src/integrationTest/java/integration/GlobalSetupExtension.java
@@ -40,7 +40,7 @@ public class GlobalSetupExtension implements BeforeAllCallback {
 
                 // need to create the default database if it does not exist
                 log.info("Setting up the default database");
-                try (Connection connection = coreConnectionFactory.create(); Statement statement = connection.createStatement()) {
+                try (Connection connection = coreConnectionFactory.create(ConnectionOptions.builder().database(null).build()); Statement statement = connection.createStatement()) {
                     statement.execute("DROP DATABASE IF EXISTS " + coreConnectionFactory.getDefaultDatabase());
                     statement.execute("CREATE DATABASE IF NOT EXISTS " + coreConnectionFactory.getDefaultDatabase());
                 }

--- a/src/integrationTest/java/integration/tests/ConnectionTest.java
+++ b/src/integrationTest/java/integration/tests/ConnectionTest.java
@@ -85,10 +85,13 @@ class ConnectionTest extends IntegrationTest {
 
     @Test
     @Tag(TestTag.CORE)
-    void connectToNotExistingDbInCore() throws SQLException {
+    void connectToNotExistingDbInCore() {
         // when backend will fix their code this test will start failing
         String database = "wrong_db";
-        createConnectionWithOptions(ConnectionOptions.builder().database(database).build());
+        FireboltException e = assertThrows(FireboltException.class, () -> createConnectionWithOptions(ConnectionOptions.builder().database(database).build()));
+        assertEquals(ExceptionType.INVALID_REQUEST, e.getType());
+        String expectedMessage = format("Database '%s' does not exist or not authorized", database);
+        assertTrue(e.getMessage().contains(expectedMessage), format("Error message '%s' does not match '%s'", e.getMessage(), expectedMessage));
     }
 
     @Test

--- a/src/integrationTest/java/integration/tests/StatementTest.java
+++ b/src/integrationTest/java/integration/tests/StatementTest.java
@@ -705,20 +705,12 @@ class StatementTest extends IntegrationTest {
 	}
 
 	@Tag(TestTag.V2)
+	@Tag(TestTag.CORE)
 	@Test
 	void cannotChangeToDatabaseThatDoesNotExist() throws SQLException {
 		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
 			SQLException exception = assertThrows(SQLException.class, () -> statement.executeUpdate("USE DATABASE \"a_db_that_does_not_exist\";"));
 			assertTrue(exception.getMessage().contains("Database 'a_db_that_does_not_exist' does not exist or not authorized."));
-		}
-	}
-
-	@Tag(TestTag.CORE)
-	@Test
-	void cannotChangeToDatabaseThatDoesNotExistForCore() throws SQLException {
-		try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
-			// this test will start failing when the backend will fix their issue, just add the Tag(TestTag.CORE) annotation to the method cannotChangeToDatabaseThatDoesNotExist
-			statement.executeUpdate("USE DATABASE \"a_db_that_does_not_exist\";");
 		}
 	}
 

--- a/src/integrationTest/resources/core/default.conf
+++ b/src/integrationTest/resources/core/default.conf
@@ -13,6 +13,5 @@ server {
     location / {
         proxy_pass http://firebolt-core:3473;
         proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
     }
 }


### PR DESCRIPTION
Backend team released the 4.23 version of the docker image. 
Some tests are failing (some expected, as they had fixed the passing of the database that does not exist in the url). So fixed those tests. 

Changed the initial setup when we create the integration_test_db to explicitly not set the database (otherwise it was getting the database from the command line arguments and it would not exist. 4.23 version checks for this and it throws an error so basically the setup for out tests is not working and thus all the tests were failing).

Removed the X-Real-IP header from nginx configuration as the backend was rejecting it in the 4.23 version

