### PR TITLE
(fix) FIR-44420 testing if the connection is valid sends an unsupported query parameter to core

### DIFF
--- a/src/integrationTest/java/integration/tests/ConnectionTest.java
+++ b/src/integrationTest/java/integration/tests/ConnectionTest.java
@@ -102,6 +102,8 @@ class ConnectionTest extends IntegrationTest {
             assertTrue(resultSet.next());
             assertEquals("1", resultSet.getString(1));
             assertFalse(resultSet.next());
+
+            assertTrue(fireboltConnection.isValid((int) TimeUnit.MILLISECONDS.toMillis(500)));
         }
     }
 
@@ -348,6 +350,8 @@ class ConnectionTest extends IntegrationTest {
             ResultSet resultSet = statement.executeQuery("SELECT 1");
             assertTrue(resultSet.next());
             assertEquals(1, resultSet.getInt(1));
+
+            assertTrue(connection.isValid((int)TimeUnit.MILLISECONDS.toMillis(500)));
         }
     }
 

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltConnection.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltConnection.java
@@ -427,8 +427,9 @@ public abstract class FireboltConnection extends JdbcBase implements Connection,
 			throws SQLException {
 		HashMap<String, String> runtimeProperties = new HashMap<>(fireboltProperties.getRuntimeAdditionalProperties());
 		if (isInternalRequest) {
-			runtimeProperties.put("auto_start_stop_control", "ignore");
+			prepareInternalRequestValidationConnection(runtimeProperties);
 		}
+
 		var propertiesBuilder = fireboltProperties.toBuilder().runtimeAdditionalProperties(runtimeProperties);
 		if (getSessionProperties().isValidateOnSystemEngine()) {
 			propertiesBuilder.compress(false).engine(null).systemEngine(true);
@@ -446,6 +447,10 @@ public abstract class FireboltConnection extends JdbcBase implements Connection,
 				throw e;
 			}
 		}
+	}
+
+	protected void prepareInternalRequestValidationConnection(Map<String, String> runtimeProperties) {
+		runtimeProperties.put("auto_start_stop_control", "ignore");
 	}
 
 	private void validateConnectionIsNotClose() throws SQLException {

--- a/src/main/java/com/firebolt/jdbc/connection/FireboltCoreConnection.java
+++ b/src/main/java/com/firebolt/jdbc/connection/FireboltCoreConnection.java
@@ -12,6 +12,7 @@ import java.net.URL;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import lombok.CustomLog;
@@ -130,6 +131,12 @@ public class FireboltCoreConnection extends FireboltConnection {
             throw new SQLException("Invalid URL format. URL must be in the form: <protocol>://<host>:<port>. "+e.getMessage());
         }
     }
+
+    @Override
+    protected void prepareInternalRequestValidationConnection(Map<String, String> runtimeProperties) {
+        // do not add the auto_start_stop_control as for core this is not supported
+    }
+
 
     @Override
     protected FireboltAuthenticationClient createFireboltAuthenticationClient(OkHttpClient httpClient) {


### PR DESCRIPTION
During connection validation the driver sends a query parameter that is not supported to core: auto_start_stop_control
Core does not execute the query received if this parameter is set and returns this error instead:

`Error: Query failed with system error: Code: 1000006, e.displayText() = Changing auto_start_stop_control is not supported in Firebolt core, Stack trace (when copying this message, always include the lines below):`

We have already factored out the query parameter provider for v1, v2, dev and core. These are the parameters that will be sent to backend as part of the URI. The simple fix is to remove the unsupported parameter before sending it back to backend. 