### PR TITLE
(cleanup) FIR-46389 remove the explicit setting of the error response format header

### DIFF
--- a/src/main/java/com/firebolt/jdbc/client/query/FireboltCoreQueryParameterProvider.java
+++ b/src/main/java/com/firebolt/jdbc/client/query/FireboltCoreQueryParameterProvider.java
@@ -1,7 +1,6 @@
 package com.firebolt.jdbc.client.query;
 
 import com.firebolt.jdbc.connection.settings.FireboltProperties;
-import com.firebolt.jdbc.connection.settings.FireboltQueryParameterKey;
 import com.firebolt.jdbc.statement.StatementInfoWrapper;
 import com.firebolt.jdbc.statement.StatementType;
 import java.util.HashMap;
@@ -29,9 +28,6 @@ public class FireboltCoreQueryParameterProvider extends AbstractQueryParameterPr
         addQueryParameterIfNeeded(params, statementInfoWrapper.getPreparedStatementParameters());
         addQueryTimeoutIfNeeded(params, queryTimeout);
         addServerAsyncIfNeeded(params, isServerAsync);
-
-        // once this will be enabled by default on core we can remove it. https://packboard.atlassian.net/browse/FIR-46389
-        params.put(FireboltQueryParameterKey.ENABLE_JSON_ERROR_OUTPUT_FORMAT.getKey(), "1");
 
         return params;
     }

--- a/src/main/java/com/firebolt/jdbc/connection/settings/FireboltQueryParameterKey.java
+++ b/src/main/java/com/firebolt/jdbc/connection/settings/FireboltQueryParameterKey.java
@@ -16,8 +16,7 @@ public enum FireboltQueryParameterKey {
 	ACCOUNT_ID("account_id"),
 	ASYNC("async"),
 	QUERY_PARAMETERS("query_parameters"),
-	MAX_EXECUTION_TIME("max_execution_time"),
-	ENABLE_JSON_ERROR_OUTPUT_FORMAT("enable_json_error_output_format"),
+	MAX_EXECUTION_TIME("max_execution_time")
 	;
 
 	private final String key;

--- a/src/test/java/com/firebolt/jdbc/client/query/FireboltCoreQueryParameterProviderTest.java
+++ b/src/test/java/com/firebolt/jdbc/client/query/FireboltCoreQueryParameterProviderTest.java
@@ -31,11 +31,10 @@ class FireboltCoreQueryParameterProviderTest extends AbstractQueryParameterProvi
 
         Map<String, String> queryParams = fireboltCoreQueryParameterProvider.getQueryParams(mockFireboltProperties, mockStatementInfoWrapper, NO_QUERY_TIMEOUT, IS_SERVER_ASYNC);
 
-        assertEquals(5, queryParams.size());
+        assertEquals(4, queryParams.size());
 
         assertEquals(STATEMENT_WRAPPER_LABEL, queryParams.get(FireboltQueryParameterKey.QUERY_LABEL.getKey()));
         assertEquals("1", queryParams.get(FireboltQueryParameterKey.COMPRESS.getKey()));
-        assertEquals("1", queryParams.get(FireboltQueryParameterKey.ENABLE_JSON_ERROR_OUTPUT_FORMAT.getKey()));
         assertEquals("true", queryParams.get(FireboltQueryParameterKey.ASYNC.getKey()));
         assertEquals("value1", queryParams.get("key1"));
     }
@@ -51,10 +50,9 @@ class FireboltCoreQueryParameterProviderTest extends AbstractQueryParameterProvi
 
         Map<String, String> queryParams = fireboltCoreQueryParameterProvider.getQueryParams(mockFireboltProperties, mockStatementInfoWrapper, QUERY_TIMEOUT, IS_NOT_SERVER_ASYNC);
 
-        assertEquals(8, queryParams.size());
+        assertEquals(7, queryParams.size());
         assertEquals(STATEMENT_WRAPPER_LABEL, queryParams.get(FireboltQueryParameterKey.QUERY_LABEL.getKey()));
         assertEquals("0", queryParams.get(FireboltQueryParameterKey.COMPRESS.getKey()));
-        assertEquals("1", queryParams.get(FireboltQueryParameterKey.ENABLE_JSON_ERROR_OUTPUT_FORMAT.getKey()));
         assertEquals(DATABASE, queryParams.get(FireboltQueryParameterKey.DATABASE.getKey()));
         assertEquals(String.valueOf(QUERY_TIMEOUT), queryParams.get(FireboltQueryParameterKey.MAX_EXECUTION_TIME.getKey()));
         assertEquals(FireboltCoreQueryParameterProvider.TAB_SEPARATED_WITH_NAMES_AND_TYPES_FORMAT, queryParams.get(FireboltQueryParameterKey.OUTPUT_FORMAT.getKey()));
@@ -73,10 +71,9 @@ class FireboltCoreQueryParameterProviderTest extends AbstractQueryParameterProvi
 
         Map<String, String> queryParams = fireboltCoreQueryParameterProvider.getQueryParams(mockFireboltProperties, mockStatementInfoWrapper, NO_QUERY_TIMEOUT, IS_NOT_SERVER_ASYNC);
 
-        assertEquals(5, queryParams.size());
+        assertEquals(4, queryParams.size());
         assertEquals(SESSION_PROPERTY_QUERY_LABEL, queryParams.get(FireboltQueryParameterKey.QUERY_LABEL.getKey()));
         assertEquals("0", queryParams.get(FireboltQueryParameterKey.COMPRESS.getKey()));
-        assertEquals("1", queryParams.get(FireboltQueryParameterKey.ENABLE_JSON_ERROR_OUTPUT_FORMAT.getKey()));
         assertEquals(FireboltCoreQueryParameterProvider.TAB_SEPARATED_WITH_NAMES_AND_TYPES_FORMAT, queryParams.get(FireboltQueryParameterKey.OUTPUT_FORMAT.getKey()));
         assertEquals("value1", queryParams.get("key1"));
 


### PR DESCRIPTION
This has been fixed for core backend so no need to explicitly set the error output header format. 