### PR TITLE
Revert wrong version number

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=.3.6.4
+version=3.6.3
 jdbcVersion=4.3


### PR DESCRIPTION
When I released I used v.3.6.4 instead of v3.6.4 so that caused a wrong version number to be set on Git.
Revert the build bump so I can release again. 