### PR TITLE
(build) FIR-46835 create variable for library version in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,10 @@ project.ext {
     codeCoverageExclusionList = [
             "**/firebolt/jdbc/client/config/**"
     ]
+    junitJupiterVersion = '5.13.1'
+    lombokVersion = '1.18.38'
+    okHttpVersion = '4.12.0'
+    slf4jVersion = '2.0.17'
 }
 
 java {
@@ -60,7 +64,7 @@ sourceSets {
 dependencies {
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
     implementation 'org.json:json:20250517'
-    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    implementation "com.squareup.okhttp3:okhttp:${okHttpVersion}"
     implementation 'net.jodah:expiringmap:0.5.11'
     implementation 'org.apache.commons:commons-text:1.13.1'
     implementation 'org.lz4:lz4-java:1.8.0'
@@ -68,27 +72,27 @@ dependencies {
 
     implementation fileTree(dir: 'libs', includes: ['*.jar'])
 
-    compileOnly 'org.slf4j:slf4j-api:2.0.17'
-    compileOnly 'org.projectlombok:lombok:1.18.38'
-    annotationProcessor 'org.projectlombok:lombok:1.18.38'
-    testCompileOnly 'org.projectlombok:lombok:1.18.38'
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.38'
+    compileOnly "org.slf4j:slf4j-api:${slf4jVersion}"
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
+    testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
     testImplementation 'ch.qos.logback:logback-classic:1.5.18'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.10.0'
     testImplementation 'org.mockito:mockito-core:5.10.0'
     testImplementation 'org.mockito:mockito-inline:5.2.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.13.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.13.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.13.1'
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:${junitJupiterVersion}"
     testImplementation 'org.junit-pioneer:junit-pioneer:2.2.0'
     testImplementation 'org.hamcrest:hamcrest-library:3.0'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
-    testImplementation 'com.squareup.okhttp3:okhttp-tls:4.12.0'
+    testImplementation "com.squareup.okhttp3:mockwebserver:${okHttpVersion}"
+    testImplementation "com.squareup.okhttp3:okhttp-tls:${okHttpVersion}"
     testImplementation 'io.zonky.test:embedded-postgres:2.1.0'
-    testCompileOnly 'org.slf4j:slf4j-api:2.0.17'
-    testCommonImplementation 'org.junit.jupiter:junit-jupiter-api:5.13.1'
-    testCommonImplementation 'org.junit.jupiter:junit-jupiter-params:5.13.1'
+    testCompileOnly "org.slf4j:slf4j-api:${slf4jVersion}"
+    testCommonImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
+    testCommonImplementation "org.junit.jupiter:junit-jupiter-params:${junitJupiterVersion}"
     testImplementation sourceSets.testCommon.output
     compileTestJava.dependsOn processTestResources
     jar.dependsOn processTestResources


### PR DESCRIPTION
When junit-jupiter releases a new version, depenadatbot creates 3 PRs, one for each of the libraries: junit-juipiter-api, junit-jupiter-engine and junit-jupiter-params. 
Also the version is duplicated in this case 5 times. 
Created variables for library versions and use the version when importing the libraries. 