### PR TITLE
(ci) FIR-46858 added the slack integration for nightly failures

### DIFF
--- a/.github/workflows/core-integration-test.yml
+++ b/.github/workflows/core-integration-test.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: string
         default: 'ubuntu-latest'
+      sendSlackNotifications:
+        description: 'Send Slack notifications on failure'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       tag_version:
@@ -33,6 +38,14 @@ on:
         required: false
         type: string
         default: 'ubuntu-latest'
+      sendSlackNotifications:
+        description: 'Send Slack notifications on failure'
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      SLACK_BOT_TOKEN:
+        required: false
 env:
   DEFAULT_IMAGE_TAG: ${{ vars.DEFAULT_CORE_IMAGE_TAG }}
 jobs:
@@ -141,3 +154,13 @@ jobs:
         if: always()
         run: |
           docker compose -f "$DOCKER_COMPOSE_FILE" down
+
+      - name: Slack Notify of failure
+        if: failure() && inputs.sendSlackNotifications
+        uses: firebolt-db/action-slack-nightly-notify@v1
+        with:
+          os: ${{ inputs.os_name }}
+          programming-language: Java
+          language-version: ${{ inputs.java_version }}
+          notifications-channel: 'ecosystem-ci-notifications'
+          slack-api-key: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/integration-test-v1.yml
+++ b/.github/workflows/integration-test-v1.yml
@@ -20,6 +20,11 @@ on:
         required: false
         type: string
         default: 'ubuntu-latest'
+      sendSlackNotifications:
+        description: 'Send Slack notifications on failure'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       database:
@@ -41,11 +46,18 @@ on:
         required: false
         type: string
         default: 'ubuntu-latest'
+      sendSlackNotifications:
+        description: 'Send Slack notifications on failure'
+        required: false
+        type: boolean
+        default: false
     secrets:
       FIREBOLT_STG_USERNAME:
         required: true
       FIREBOLT_STG_PASSWORD:
         required: true
+      SLACK_BOT_TOKEN:
+        required: false
 
 jobs:
   run-integration-tests:
@@ -116,3 +128,13 @@ jobs:
 
       - name: Run integration tests
         run: ./gradlew integrationTest -Ddb="${{ steps.find-database-name.outputs.database_name }}" -Dapi="api.staging.firebolt.io" -Dpassword="${{ secrets.FIREBOLT_STG_PASSWORD }}" -Duser="${{ secrets.FIREBOLT_STG_USERNAME }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DincludeTags="v1" -Dv1GenerateSeriesMaxSize="${{ vars.V1_GENERATE_SERIES_MAX_SIZE }}"
+
+      - name: Slack Notify of failure
+        if: failure() && inputs.sendSlackNotifications
+        uses: firebolt-db/action-slack-nightly-notify@v1
+        with:
+          os: ${{ inputs.os_name }}
+          programming-language: Java
+          language-version: ${{ inputs.java_version }}
+          notifications-channel: 'ecosystem-ci-notifications'
+          slack-api-key: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/integration-test-v2.yml
+++ b/.github/workflows/integration-test-v2.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: string
         default: 'ubuntu-latest'
+      sendSlackNotifications:
+        description: 'Send Slack notifications on failure'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       database:
@@ -49,11 +54,18 @@ on:
         required: false
         type: string
         default: 'ubuntu-latest'
+      sendSlackNotifications:
+        description: 'Send Slack notifications on failure'
+        required: false
+        type: boolean
+        default: false
     secrets:
       FIREBOLT_CLIENT_ID_STG_NEW_IDN:
         required: true
       FIREBOLT_CLIENT_SECRET_STG_NEW_IDN:
         required: true
+      SLACK_BOT_TOKEN:
+        required: false
 
 jobs:
   run-integration-tests:
@@ -134,3 +146,13 @@ jobs:
 
       - name: Run integration tests
         run: ./gradlew integrationTest -Ddb="${{ steps.find-database-name.outputs.database_name }}" -Denv="staging" -Dclient_secret="${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}" -Dclient_id="${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}" -Daccount="${{ steps.set-account.outputs.account }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DincludeTags="v2" -Dv2GenerateSeriesMaxSize="${{ vars.V2_GENERATE_SERIES_MAX_SIZE }}"
+
+      - name: Slack Notify of failure
+        if: failure() && inputs.sendSlackNotifications
+        uses: firebolt-db/action-slack-nightly-notify@v1
+        with:
+          os: ${{ inputs.os_name }}
+          programming-language: Java
+          language-version: ${{ inputs.java_version }}
+          notifications-channel: 'ecosystem-ci-notifications'
+          slack-api-key: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/nightly-core.yml
+++ b/.github/workflows/nightly-core.yml
@@ -91,4 +91,5 @@ jobs:
       os_name: ubuntu-latest
       java_version: 11
       tag_version: ${{ matrix.image.tag }}
+      sendSlackNotifications: true
     secrets: inherit

--- a/.github/workflows/nightly-v1.yaml
+++ b/.github/workflows/nightly-v1.yaml
@@ -21,6 +21,8 @@ jobs:
     with:
       os_name: ${{ matrix.os }}
       java_version: ${{ matrix.java }}
+      sendSlackNotifications: true
     secrets:
       FIREBOLT_STG_USERNAME: ${{ secrets.FIREBOLT_STG_USERNAME }}
       FIREBOLT_STG_PASSWORD: ${{ secrets.FIREBOLT_STG_PASSWORD }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/nightly-v2.yaml
+++ b/.github/workflows/nightly-v2.yaml
@@ -21,6 +21,8 @@ jobs:
     with:
       os_name: ${{ matrix.os }}
       java_version: ${{ matrix.java }}
+      sendSlackNotifications: true
     secrets:
       FIREBOLT_CLIENT_ID_STG_NEW_IDN: ${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}
       FIREBOLT_CLIENT_SECRET_STG_NEW_IDN: ${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
JDBC was the only one remaining from the drivers that did not have the slack integration for nightly in case of a failure. Add the slack integration for: v1, v2 and core nightlies.

Modify the underlying integration tests to accept a parameter to send notifications or not. When ran directly the default is false, when ran from the nightly it will pass in true for sending the slack notifications and also the slack token. Tests it for v2 with some failures and the messages get to slack. 
