### PR TITLE
ci(NoTicket): Increase the wait time for checking if more records have been written

### DIFF
--- a/src/integrationTest/java/integration/tests/StatementCancelTest.java
+++ b/src/integrationTest/java/integration/tests/StatementCancelTest.java
@@ -58,6 +58,7 @@ class StatementCancelTest extends IntegrationTest {
 			long now = System.currentTimeMillis();
 			fillStatement.execute("insert into ex_lineitem ( l_orderkey ) SELECT * FROM GENERATE_SERIES(1, 100000000)");
 			long insertTime = System.currentTimeMillis() - now;
+			log.info("Insert time took: {} millis", insertTime);
 
 			try (Statement insertStatement = connection.createStatement()) {
 
@@ -78,7 +79,9 @@ class StatementCancelTest extends IntegrationTest {
 				while (!((FireboltStatement)insertStatement).isStatementRunning()) {
 					Thread.sleep(100);
 				}
-				Thread.sleep(insertTime / 10); // wait 10% of time that was spent to fill data to give chance to the insert statement to copy data
+				Thread.sleep(insertTime / 5); // wait 20% of time that was spent to fill data to give chance to the insert statement to copy data
+
+				log.info("Cancelling the statement");
 				insertStatement.cancel(); // now cancel the statement
 			}
 			verifyThatNoMoreRecordsAreAdded(connection, "first_statement_cancel_test", insertTime);


### PR DESCRIPTION
v1 tests have been failing on and off for the last 2 weeks (about 3 times in 14 days)

The issue is that we create an insert statement and then cancel it. 
We then wait for some time, get how many records were inserted, wait a bit more and then check that the same number of rows exist (so no more insert happened, thus the query has been actually cancelled).

Increase the amount of time that we wait to check for new records. 

One run of nightly's passed. Another one is in progress. I will run it 5 times, hopefully we won't see any failures. 