### PR TITLE
build: FIR-47755 migrate release to maven portal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -310,8 +310,8 @@ publishing {
 
     repositories {
         maven {
-            def releasesRepoUrl = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
-            def snapshotsRepoUrl = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+            def releasesRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
+            def snapshotsRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/'
 
             url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
             credentials {


### PR DESCRIPTION
Moved package release to Maven Portal, since OSSRH has reached end of life.
According to their docs (https://central.sonatype.org/pages/ossrh-eol/#logging-in-to-central-portal), we need to:
- update publishing links
- update repo credentials to Portal-ones (already update repository secrets)