### PR TITLE
Fir 47755 migrate jdbc publishing to maven central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,3 +93,9 @@ jobs:
         MAVEN_REPO_PASSWORD: ${{ secrets.MAVEN_REPO_PASSWORD }}
         GRADLE_SIGNING_KEY: ${{ secrets.GRADLE_SIGNING_KEY }}
         GRADLE_SIGNING_PASSWORD: ${{ secrets.GRADLE_SIGNING_PASSWORD }}
+
+    - name: Trigger manual package upload via API
+      run: ./gradlew manualUploadToMavenCentral
+      env:
+        MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
+        MAVEN_REPO_PASSWORD: ${{ secrets.MAVEN_REPO_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,25 +36,25 @@ jobs:
         sed -i.bak "s/^version=.*/version=$newVersion/" gradle.properties
         rm gradle.properties.bak
 
-    - name: Setup git config
-      run: |
-        git config user.name "GitHub Actions Bot"
-        git config user.email "<>"
+#    - name: Setup git config
+#      run: |
+#        git config user.name "GitHub Actions Bot"
+#        git config user.email "<>"
 
-    - name: Commit version bump
-      run: |
-        git add gradle.properties
-        git commit -m "chore: Bump version to $newVersion"
+#    - name: Commit version bump
+#      run: |
+#        git add gradle.properties
+#        git commit -m "chore: Bump version to $newVersion"
 
-    - name: Tag version
-      run: |
-        git tag $newVersion
+#    - name: Tag version
+#      run: |
+#        git tag $newVersion
 
-    - name: Push changes
-      run: |
-        git push origin master
+#    - name: Push changes
+#      run: |
+#        git push origin master
         # Push tag
-        git push origin $newVersion
+#        git push origin $newVersion
 
   build:
     needs: bump-version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,11 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.RELEASE_PAT }}
 
-    - name: Bump version in gradle.properties
-      run: |
-        newVersion=$(echo $newVersion | sed 's/^v//')
-        sed -i.bak "s/^version=.*/version=$newVersion/" gradle.properties
-        rm gradle.properties.bak
+#    - name: Bump version in gradle.properties
+#      run: |
+#        newVersion=$(echo $newVersion | sed 's/^v//')
+#        sed -i.bak "s/^version=.*/version=$newVersion/" gradle.properties
+#        rm gradle.properties.bak
 
 #    - name: Setup git config
 #      run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,14 +78,14 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ needs.build.outputs.sources-jar }}
-    - uses: xresloader/upload-to-github-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        file: ${{ needs.build.outputs.uber-jar }}
-        tags: true
-        draft: false
-        tag_name: ${{ github.event.inputs.tag_name }}
+#    - uses: xresloader/upload-to-github-release@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        file: ${{ needs.build.outputs.uber-jar }}
+#        tags: true
+#        draft: false
+#        tag_name: ${{ github.event.inputs.tag_name }}
     - name: Deploy to Maven Central repository
       run: ./gradlew publish
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,41 +30,41 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.RELEASE_PAT }}
 
-#    - name: Bump version in gradle.properties
-#      run: |
-#        newVersion=$(echo $newVersion | sed 's/^v//')
-#        sed -i.bak "s/^version=.*/version=$newVersion/" gradle.properties
-#        rm gradle.properties.bak
+    - name: Bump version in gradle.properties
+      run: |
+        newVersion=$(echo $newVersion | sed 's/^v//')
+        sed -i.bak "s/^version=.*/version=$newVersion/" gradle.properties
+        rm gradle.properties.bak
 
-#    - name: Setup git config
-#      run: |
-#        git config user.name "GitHub Actions Bot"
-#        git config user.email "<>"
+    - name: Setup git config
+      run: |
+        git config user.name "GitHub Actions Bot"
+        git config user.email "<>"
 
-#    - name: Commit version bump
-#      run: |
-#        git add gradle.properties
-#        git commit -m "chore: Bump version to $newVersion"
+    - name: Commit version bump
+      run: |
+        git add gradle.properties
+        git commit -m "chore: Bump version to $newVersion"
 
-#    - name: Tag version
-#      run: |
-#        git tag $newVersion
+    - name: Tag version
+      run: |
+        git tag $newVersion
 
-#    - name: Push changes
-#      run: |
-#        git push origin master
+    - name: Push changes
+      run: |
+        git push origin master
         # Push tag
-#        git push origin $newVersion
+        git push origin $newVersion
 
-#  build:
-#    needs: bump-version
-#    uses: ./.github/workflows/build.yml
-#    with:
-#      branch: ${{ github.event.inputs.tag_name }}
+  build:
+    needs: bump-version
+    uses: ./.github/workflows/build.yml
+    with:
+      branch: ${{ github.event.inputs.tag_name }}
 
   publish:
     runs-on: ubuntu-latest
-#    needs: build
+    needs: build
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -78,14 +78,14 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ needs.build.outputs.sources-jar }}
-#    - uses: xresloader/upload-to-github-release@v1
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        file: ${{ needs.build.outputs.uber-jar }}
-#        tags: true
-#        draft: false
-#        tag_name: ${{ github.event.inputs.tag_name }}
+    - uses: xresloader/upload-to-github-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        file: ${{ needs.build.outputs.uber-jar }}
+        tags: true
+        draft: false
+        tag_name: ${{ github.event.inputs.tag_name }}
     - name: Deploy to Maven Central repository
       run: ./gradlew publish
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: build
+#    needs: build
     steps:
     - name: Check out code
       uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,11 @@ jobs:
         # Push tag
 #        git push origin $newVersion
 
-  build:
-    needs: bump-version
-    uses: ./.github/workflows/build.yml
-    with:
-      branch: ${{ github.event.inputs.tag_name }}
+#  build:
+#    needs: bump-version
+#    uses: ./.github/workflows/build.yml
+#    with:
+#      branch: ${{ github.event.inputs.tag_name }}
 
   publish:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -322,6 +322,41 @@ publishing {
     }
 }
 
+// https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#ensuring-deployment-visibility-in-the-central-publisher-portal
+task manualUploadToMavenCentral {
+    doLast {
+        def mavenUsername = System.getenv("MAVEN_REPO_USERNAME")
+        def mavenPassword = System.getenv("MAVEN_REPO_PASSWORD")
+        if (!mavenUsername || !mavenPassword) {
+            throw new GradleException("Missing Maven credentials")
+        }
+
+        def credentials = "${mavenUsername}:${mavenPassword}".bytes.encodeBase64().toString()
+
+        def mavenHost = "https://ossrh-staging-api.central.sonatype.com"
+        def namespace = "io.firebolt"
+        def apiUrl = "${mavenHost}/manual/upload/defaultRepository/${namespace}"
+
+        println "Calling API: $apiUrl"
+
+        def process = ["curl", "-X", "POST", apiUrl,
+                       "-H", "Authorization: Bearer ${credentials}",
+                       "-H", "Content-Type: application/json",
+                       "-d", "{}",
+                       "--fail-with-body"].execute()
+
+        def output = new StringBuffer()
+        def error = new StringBuffer()
+        process.waitForProcessOutput(output, error)
+
+        if (process.exitValue() != 0) {
+            throw new GradleException("API call failed: $output")
+        }
+
+        println "API call succeeded: $output"
+    }
+}
+
 jar {
     manifest {
         attributes(

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=3.6.7
+version=3.6.6
 jdbcVersion=4.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=3.6.6
+version=3.6.7
 jdbcVersion=4.3


### PR DESCRIPTION
Added a manual upload step for a package from Maven docs: 
https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#ensuring-deployment-visibility-in-the-central-publisher-portal