### PR TITLE
ci(NoTicket): Add allure report generation

### DIFF
--- a/.github/workflows/core-integration-test.yml
+++ b/.github/workflows/core-integration-test.yml
@@ -76,13 +76,14 @@ jobs:
           GRADLE_OPTS: -Dorg.gradle.daemon=false
 
       - name: Allure Report
-        uses: firebolt-db/action-allure-report@main
+        uses: firebolt-db/action-allure-report@keep-files
         if: always() # Needed in order to report failed tests
         with:
             github-key: ${{ secrets.GITHUB_TOKEN }}
             test-type: core
             allure-dir: build/allure-results
             pages-branch: gh-pages
+            keep-files: true
 
       - name: Slack Notify of failure
         if: failure() && inputs.sendSlackNotifications

--- a/.github/workflows/core-integration-test.yml
+++ b/.github/workflows/core-integration-test.yml
@@ -76,7 +76,7 @@ jobs:
           GRADLE_OPTS: -Dorg.gradle.daemon=false
 
       - name: Allure Report
-        uses: firebolt-db/action-allure-report@keep-files
+        uses: firebolt-db/action-allure-report@v1
         if: always() # Needed in order to report failed tests
         with:
             github-key: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/core-integration-test.yml
+++ b/.github/workflows/core-integration-test.yml
@@ -75,6 +75,15 @@ jobs:
         env:
           GRADLE_OPTS: -Dorg.gradle.daemon=false
 
+      - name: Allure Report
+        uses: firebolt-db/action-allure-report@main
+        if: always() # Needed in order to report failed tests
+        with:
+            github-key: ${{ secrets.GITHUB_TOKEN }}
+            test-type: core
+            allure-dir: build/allure-results
+            pages-branch: gh-pages
+
       - name: Slack Notify of failure
         if: failure() && inputs.sendSlackNotifications
         uses: firebolt-db/action-slack-nightly-notify@v1

--- a/.github/workflows/integration-test-v1.yml
+++ b/.github/workflows/integration-test-v1.yml
@@ -129,6 +129,16 @@ jobs:
       - name: Run integration tests
         run: ./gradlew integrationTest -Ddb="${{ steps.find-database-name.outputs.database_name }}" -Dapi="api.staging.firebolt.io" -Dpassword="${{ secrets.FIREBOLT_STG_PASSWORD }}" -Duser="${{ secrets.FIREBOLT_STG_USERNAME }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DincludeTags="v1" -Dv1GenerateSeriesMaxSize="${{ vars.V1_GENERATE_SERIES_MAX_SIZE }}"
 
+      - name: Allure Report
+        uses: firebolt-db/action-allure-report@v1
+        if: always() # Needed in order to report failed tests
+        with:
+            github-key: ${{ secrets.GITHUB_TOKEN }}
+            test-type: integration_v1
+            allure-dir: build/allure-results
+            pages-branch: gh-pages
+            keep-files: true
+
       - name: Slack Notify of failure
         if: failure() && inputs.sendSlackNotifications
         uses: firebolt-db/action-slack-nightly-notify@v1

--- a/.github/workflows/integration-test-v2.yml
+++ b/.github/workflows/integration-test-v2.yml
@@ -147,6 +147,16 @@ jobs:
       - name: Run integration tests
         run: ./gradlew integrationTest -Ddb="${{ steps.find-database-name.outputs.database_name }}" -Denv="staging" -Dclient_secret="${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}" -Dclient_id="${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}" -Daccount="${{ steps.set-account.outputs.account }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DincludeTags="v2" -Dv2GenerateSeriesMaxSize="${{ vars.V2_GENERATE_SERIES_MAX_SIZE }}"
 
+      - name: Allure Report
+        uses: firebolt-db/action-allure-report@v1
+        if: always() # Needed in order to report failed tests
+        with:
+            github-key: ${{ secrets.GITHUB_TOKEN }}
+            test-type: integration_v2
+            allure-dir: build/allure-results
+            pages-branch: gh-pages
+            keep-files: true
+
       - name: Slack Notify of failure
         if: failure() && inputs.sendSlackNotifications
         uses: firebolt-db/action-slack-nightly-notify@v1

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'maven-publish'
     id 'com.github.johnrengelman.shadow' version '8.0.0'
     id 'signing'
+    id 'io.qameta.allure' version '2.11.2'
 }
 
 group 'io.firebolt'
@@ -103,6 +104,7 @@ dependencies {
     compileTestCommonJava.dependsOn processIntegrationTestResources
     compileIntegrationTestJava.dependsOn processIntegrationTestResources
     javadoc.options.addStringOption('Xdoclint:none', '-quiet')
+    testImplementation 'io.qameta.allure:allure-junit5:2.25.0'
 }
 
 test {
@@ -375,6 +377,13 @@ jar {
     }
 }
 
+allure {
+    version = '2.25.0'
+    autoconfigure = true
+    useJUnit5 {
+        version = '2.25.0'
+    }
+}
 
 task generateJavadoc(type: Javadoc) {
     failOnError false


### PR DESCRIPTION
This generates nice visual reports so we don't have to scroll through large text logs to find and debug failures.
Example: https://jdbc.docs.firebolt.io/allure/_645a23630e79aabb8ede69f4caa71c87d279479c_core/59/index.html