### PR TITLE
ci: Run allure on Linux only

### DIFF
--- a/.github/workflows/core-integration-test.yml
+++ b/.github/workflows/core-integration-test.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Allure Report
         uses: firebolt-db/action-allure-report@v1
-        if: always() # Needed in order to report failed tests
+        if: always() && runner.os == 'Linux' # Needed in order to report failed tests
         with:
             github-key: ${{ secrets.GITHUB_TOKEN }}
             test-type: core

--- a/.github/workflows/integration-test-v1.yml
+++ b/.github/workflows/integration-test-v1.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Allure Report
         uses: firebolt-db/action-allure-report@v1
-        if: always() # Needed in order to report failed tests
+        if: always() && runner.os == 'Linux' # Needed in order to report failed tests
         with:
             github-key: ${{ secrets.GITHUB_TOKEN }}
             test-type: integration_v1

--- a/.github/workflows/integration-test-v2.yml
+++ b/.github/workflows/integration-test-v2.yml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Allure Report
         uses: firebolt-db/action-allure-report@v1
-        if: always() # Needed in order to report failed tests
+        if: always() && runner.os == 'Linux' # Needed in order to report failed tests
         with:
             github-key: ${{ secrets.GITHUB_TOKEN }}
             test-type: integration_v2


### PR DESCRIPTION
One of the actions that we're using can't be run on other os's since it's a containerised action. Setting allure to run on linux only for now.