### PR TITLE
(fix) FIR-48576 allow graceful JVM termination when using caching

### DIFF
--- a/src/main/java/com/firebolt/jdbc/cache/FileService.java
+++ b/src/main/java/com/firebolt/jdbc/cache/FileService.java
@@ -43,7 +43,7 @@ public class FileService {
     private static ThreadFactory createDaemonThreadFactory() {
         final AtomicInteger threadNumber = new AtomicInteger(1);
         return runnable -> {
-            Thread thread = new Thread(runnable, "firebolt-jdbc-cache-" + threadNumber.getAndIncrement());
+            Thread thread = new Thread(runnable, "firebolt-jdbc-cache-" + threadNumber.getAndIncrement() + "d");
             thread.setDaemon(true);
             return thread;
         };


### PR DESCRIPTION
The OnDiskCachingService was creating 2 threads that were not set to be as daemon. So this would sometimes, not always, prevent the JVM to gracefully stops. 100% it was preventing runs on GitHub actions, but maybe 20-30% locally on my Mac. 

I did use the JDK Mission Control to get the stack trace to identify which class is creating the 2 threads:
Stack Trace	Count	Percentage
boolean java.util.concurrent.ThreadPoolExecutor.addWorker(Runnable, boolean)	1	100 %
void java.util.concurrent.ThreadPoolExecutor.execute(Runnable)	1	100 %
Future java.util.concurrent.AbstractExecutorService.submit(Runnable)	1	100 %
void com.firebolt.jdbc.cache.FileService.safeSaveToDiskAsync(CacheKey, ConnectionCache)	1	100 %
void com.firebolt.jdbc.cache.OnDiskMemoryCacheService.safelySaveToDiskAsync(CacheKey, ConnectionCache)	1	100 %
void com.firebolt.jdbc.cache.OnDiskMemoryCacheService.put(CacheKey, ConnectionCache)	1	100 %
void com.firebolt.jdbc.connection.FireboltConnectionServiceSecret.prepareCacheIfNeeded()	1	100 %
void com.firebolt.jdbc.connection.FireboltConnectionServiceSecret.authenticate()	1	100 %
void com.firebolt.jdbc.connection.FireboltConnection.connect()	1	100 %
void com.firebolt.jdbc.connection.FireboltConnectionServiceSecret.<init>(String, Properties, ConnectionIdGenerator, CacheService)	1	100 %
FireboltConnectionServiceSecret com.firebolt.jdbc.connection.FireboltConnectionProvider$FireboltConnectionProviderWrapper.createFireboltConnectionServiceSecret(String, Properties)	1	100 %
FireboltConnection com.firebolt.jdbc.connection.FireboltConnectionProvider.create(String, Properties)	1	100 %
Connection com.firebolt.FireboltDriver.connect(String, Properties)	1	100 %
Connection java.sql.DriverManager.getConnection(String, Properties, Class)	1	100 %
Connection java.sql.DriverManager.getConnection(String, Properties)	1	100 %
void com.firebolt.kafka.connect.clients.FireboltClient.<init>(String, String, String)	1	100 %
FireboltClient com.firebolt.kafka.connect.clients.FireboltClient.createFor(String)	1	100 %
FireboltClient com.firebolt.kafka.connect.load.LoadTestRunner.getFireboltClient(String, String, String)	1	100 %
LoadTestRunResult com.firebolt.kafka.connect.load.LoadTestRunner.run()	1	100 %
void com.firebolt.kafka.connect.load.LoadTest.main(String[])	1	100 %


Fix: set them as daemons so that they can be killed when the main process ends and also set them with a name so we can identify them easier. 