### PR TITLE
 ci (FIR-48710) Fixed flaky tests for exception type

### DIFF
--- a/.github/workflows/integration-test-v2.yml
+++ b/.github/workflows/integration-test-v2.yml
@@ -145,7 +145,39 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run integration tests
-        run: ./gradlew integrationTest -Ddb="${{ steps.find-database-name.outputs.database_name }}" -Denv="staging" -Dclient_secret="${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}" -Dclient_id="${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}" -Daccount="${{ steps.set-account.outputs.account }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DincludeTags="v2" -Dv2GenerateSeriesMaxSize="${{ vars.V2_GENERATE_SERIES_MAX_SIZE }}"
+        run: ./gradlew integrationTest -Ddb="${{ steps.find-database-name.outputs.database_name }}" -Denv="staging" -Dclient_secret="${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}" -Dclient_id="${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}" -Daccount="${{ steps.set-account.outputs.account }}" -Dengine="${{ steps.find-engine-name.outputs.engine_name }}" -DincludeTags="v2" -Dv2GenerateSeriesMaxSize="${{ vars.V2_GENERATE_SERIES_MAX_SIZE }}" -DintegrationTestMaxHeap=3g
+
+      - name: Upload integration test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integrationTest-reports-${{ inputs.os_name }}-java${{ inputs.java_version }}
+          path: |
+            build/reports/tests/integrationTest
+            build/test-results/integrationTest
+            build/reports/problems
+            build/reports/tests/test
+            build/test-results/test
+          if-no-files-found: warn
+          retention-days: 4
+
+      # Collect logs into workspace (Linux/macOS)
+      - name: Collect Gradle logs (unix)
+        if: always() && runner.os != 'Windows'
+        shell: bash
+        run: |
+          mkdir -p build/ci-logs/gradle
+          cp ~/.gradle/daemon/*/*.log build/ci-logs/gradle 2>/dev/null || true
+          find . -type f \( -name 'hs_err_pid*.log' -o -name 'replay_pid*.log' \) -exec cp {} build/ci-logs \; 2>/dev/null || true
+
+      # Collect logs into workspace (Windows)
+      - name: Collect Gradle logs (windows)
+        if: always() && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path build\ci-logs\gradle | Out-Null
+          Get-ChildItem -Path $env:USERPROFILE\.gradle\daemon\*\*.log -ErrorAction SilentlyContinue | Copy-Item -Destination build\ci-logs\gradle -ErrorAction SilentlyContinue
+          Get-ChildItem -Path . -Recurse -Include hs_err_pid*.log,replay_pid*.log -ErrorAction SilentlyContinue | Copy-Item -Destination build\ci-logs -ErrorAction SilentlyContinue
 
       - name: Allure Report
         uses: firebolt-db/action-allure-report@v1

--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,15 @@ tasks.register('integrationTest', Test) {
         includeTags(System.getProperty("includeTags", "v2").split(","))
         excludeTags(System.getProperty("excludeTags", "nothing").split(","))
     }
+    // Increase heap to avoid OOM when building very large merged SQL batches in tests
+    maxHeapSize = System.getProperty("integrationTestMaxHeap", "2g")
+    // Helpful JVM flags and opens for tests
+    jvmArgs(
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--add-opens=java.base/java.util=ALL-UNNAMED",
+        "-XX:+HeapDumpOnOutOfMemoryError",
+        "-XX:HeapDumpPath=${buildDir}/heapdumps"
+    )
     reports {
         junitXml {
             outputPerTestCase = true // defaults to false
@@ -153,6 +162,12 @@ tasks.register('integrationTest', Test) {
             println "\nTest result: ${result.resultType}"
             println "Tests run: ${result.testCount}, Passed: ${result.successfulTestCount}, Failed: ${result.failedTestCount}, Skipped: ${result.skippedTestCount}"
         }
+    }
+
+    // Ensure heap dump directory exists if OOM happens
+    doFirst {
+        file("${buildDir}/heapdumps").mkdirs()
+        println "integrationTest JVM maxHeapSize=${maxHeapSize}"
     }
 }
 


### PR DESCRIPTION
When generating a test with a payload of 40 MB some times the runner fails and crashes: 

`Caused by: java.lang.OutOfMemoryError: Java heap space
	at java.base/java.util.Arrays.copyOf(Arrays.java:3745)
	at java.base/java.lang.AbstractStringBuilder.ensureCapacityInternal(AbstractStringBuilder.java:172)
	at java.base/java.lang.AbstractStringBuilder.append(AbstractStringBuilder.java:538)
	at java.base/java.lang.StringBuilder.append(StringBuilder.java:179)
	at com.firebolt.jdbc.statement.preparedstatement.FireboltPreparedStatement.asSingleStatement(FireboltPreparedStatement.java:292)
	at com.firebolt.jdbc.statement.preparedstatement.FireboltPreparedStatement.executeBatch(FireboltPreparedStatement.java:276)
	at integration.tests.ExceptionTypeTest.shouldThrowRequestBodyTooLargeExceptionForLargeData(ExceptionTypeTest.java:77)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)`