### PR TITLE
ci(FIR-48984): Skip allure if it fails

### DIFF
--- a/.github/workflows/integration-test-v1.yml
+++ b/.github/workflows/integration-test-v1.yml
@@ -132,6 +132,7 @@ jobs:
       - name: Allure Report
         uses: firebolt-db/action-allure-report@v1
         if: always() && runner.os == 'Linux' # Needed in order to report failed tests
+        continue-on-error: true # FIR-48984
         with:
             github-key: ${{ secrets.GITHUB_TOKEN }}
             test-type: integration_v1

--- a/.github/workflows/integration-test-v2.yml
+++ b/.github/workflows/integration-test-v2.yml
@@ -182,6 +182,7 @@ jobs:
       - name: Allure Report
         uses: firebolt-db/action-allure-report@v1
         if: always() && runner.os == 'Linux' # Needed in order to report failed tests
+        continue-on-error: true # FIR-48984
         with:
             github-key: ${{ secrets.GITHUB_TOKEN }}
             test-type: integration_v2


### PR DESCRIPTION
Allure fails if another process writes to gh-pages beforehand. For now ignoring the failure.