### PR TITLE
fix(metadata): return correct display size for all data types (FB-762)

### DIFF
--- a/src/main/java/com/firebolt/jdbc/resultset/FireboltResultSetMetaData.java
+++ b/src/main/java/com/firebolt/jdbc/resultset/FireboltResultSetMetaData.java
@@ -2,6 +2,8 @@ package com.firebolt.jdbc.resultset;
 
 import com.firebolt.jdbc.GenericWrapper;
 import com.firebolt.jdbc.resultset.column.Column;
+import com.firebolt.jdbc.resultset.column.ColumnType;
+import com.firebolt.jdbc.type.TypeDisplaySize;
 
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -114,8 +116,8 @@ public class FireboltResultSetMetaData implements ResultSetMetaData, GenericWrap
 
 	@Override
 	public int getColumnDisplaySize(int column) throws SQLException {
-		checkColumnNumber(column);
-		return 80; // Default value for backward compatibility
+		ColumnType type = getColumn(column).getType();
+		return TypeDisplaySize.getDisplaySize(type.getDataType(), type.getPrecision(), type.getScale());
 	}
 	@Override
 	public String getSchemaName(int column) throws SQLException {

--- a/src/main/java/com/firebolt/jdbc/type/TypeDisplaySize.java
+++ b/src/main/java/com/firebolt/jdbc/type/TypeDisplaySize.java
@@ -1,0 +1,102 @@
+package com.firebolt.jdbc.type;
+
+/**
+ * Utility class for computing JDBC column display sizes.
+ * Based on PostgreSQL JDBC driver (pgjdbc) implementation.
+ *
+ * @see <a href="https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java#L658-L735">pgjdbc TypeInfoCache.getDisplaySize()</a>
+ */
+public final class TypeDisplaySize {
+
+	/**
+	 * Default value to return for types with unknown/unlimited length.
+	 * Following PostgreSQL JDBC convention.
+	 */
+	public static final int UNKNOWN_LENGTH = Integer.MAX_VALUE;
+
+	private TypeDisplaySize() {
+	}
+
+	/**
+	 * Returns the display size for a column type.
+	 * Display sizes for numeric types match PostgreSQL JDBC exactly.
+	 *
+	 * @param dataType  the Firebolt data type
+	 * @param precision the column precision (type modifier), 0 or negative if unknown
+	 * @param scale     the column scale, 0 or negative if unknown
+	 * @return the display size in characters
+	 */
+	public static int getDisplaySize(FireboltDataType dataType, int precision, int scale) {
+		switch (dataType) {
+			// Boolean - PostgreSQL returns 1 for BOOL
+			case BOOLEAN:
+			case U_INT_8:    // UInt8 is used for boolean internally
+				return 1;
+
+			// Integer types - display size includes sign
+			// PostgreSQL: INT4 -> 11, INT8 -> 20
+			case INTEGER:    // Int32 / INTEGER (also covers Int8, Int16 which map to INTEGER)
+				return 11; // -2147483648 to +2147483647
+			case BIG_INT:    // Int64 / BIGINT
+			case BIG_INT_64:
+			case UNSIGNED_BIG_INT_64:
+				return 20; // -9223372036854775808 to +9223372036854775807
+
+			// Floating point types - includes sign, digits, decimal, exponent
+			// PostgreSQL: FLOAT4 -> 15, FLOAT8 -> 25
+			case REAL:       // Float32 / REAL
+				return 15; // sign + 9 digits + decimal point + e + sign + 2 digits
+			case DOUBLE_PRECISION: // Float64 / DOUBLE PRECISION
+				return 25; // sign + 18 digits + decimal point + e + sign + 3 digits
+
+			// Text/String types
+			case TEXT:
+				// If precision is specified (VARCHAR(n)), use it
+				// Otherwise return UNKNOWN_LENGTH for TEXT
+				if (precision > 0) {
+					return precision;
+				}
+				return UNKNOWN_LENGTH;
+
+			// Date/Time types - PostgreSQL reference values
+			case DATE:
+			case DATE_32:
+				return 13; // "4713-01-01 BC" format (PostgreSQL uses 13)
+			case TIMESTAMP:
+			case DATE_TIME_64:
+				// timestamp without time zone: YYYY-MM-DD HH:MM:SS.ffffff
+				return 26; // 10 (date) + 1 (space) + 15 (time with microseconds)
+			case TIMESTAMP_WITH_TIMEZONE:
+				// timestamp with time zone: YYYY-MM-DD HH:MM:SS.ffffff+HH:MM
+				return 32; // 26 + 6 (timezone offset)
+
+			// Numeric/Decimal
+			// PostgreSQL: unbounded NUMERIC -> 131089
+			case NUMERIC:
+				if (precision > 0) {
+					// sign + precision digits + decimal point (if scale > 0)
+					return 1 + precision + (scale > 0 ? 1 : 0);
+				}
+				// PostgreSQL returns 131089 for unbounded NUMERIC
+				return 131089;
+
+			// Binary types - unlimited
+			case BYTEA:
+				return UNKNOWN_LENGTH;
+
+			// Complex/unlimited types
+			case ARRAY:
+			case TUPLE:
+			case STRUCT:
+			case JSON:
+			case GEOGRAPHY:
+				return UNKNOWN_LENGTH;
+
+			// Unknown or other types - return UNKNOWN_LENGTH
+			case NOTHING:
+			case UNKNOWN:
+			default:
+				return UNKNOWN_LENGTH;
+		}
+	}
+}

--- a/src/test/java/com/firebolt/jdbc/resultset/FireboltResultSetMetaDataTest.java
+++ b/src/test/java/com/firebolt/jdbc/resultset/FireboltResultSetMetaDataTest.java
@@ -110,10 +110,30 @@ class FireboltResultSetMetaDataTest {
 		assertFalse(md.isAutoIncrement(1));
 		assertTrue(md.isSearchable(1));
 		assertFalse(md.isCurrency(1));
-		assertEquals(80, md.getColumnDisplaySize(1));
 		assertEquals("", md.getSchemaName(1));
 		assertFalse(md.isWritable(1));
 		assertFalse(md.isDefinitelyWritable(1));
+	}
+
+	@Test
+	void getColumnDisplaySize_textColumn_returnsMaxValue() throws SQLException {
+		// TEXT column without precision should return Integer.MAX_VALUE
+		ResultSetMetaData md = getMetaData();
+		assertEquals(Integer.MAX_VALUE, md.getColumnDisplaySize(1)); // String/TEXT column
+	}
+
+	@Test
+	void getColumnDisplaySize_integerColumn_returns11() throws SQLException {
+		// INTEGER column should return 11 (PostgreSQL convention)
+		ResultSetMetaData md = getMetaData();
+		assertEquals(11, md.getColumnDisplaySize(2)); // Integer column
+	}
+
+	@Test
+	void getColumnDisplaySize_numericColumn_returnsPrecisionPlusSignAndDecimal() throws SQLException {
+		// NUMERIC(1,2) should return 1 + 1 + 1 = 3 (sign + precision + decimal point)
+		ResultSetMetaData md = getMetaData();
+		assertEquals(3, md.getColumnDisplaySize(3)); // Decimal(1,2) column
 	}
 
 	@ParameterizedTest

--- a/src/test/java/com/firebolt/jdbc/type/TypeDisplaySizeTest.java
+++ b/src/test/java/com/firebolt/jdbc/type/TypeDisplaySizeTest.java
@@ -1,0 +1,172 @@
+package com.firebolt.jdbc.type;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link TypeDisplaySize}.
+ * Display sizes follow PostgreSQL JDBC conventions.
+ *
+ * @see <a href="https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java#L658-L735">pgjdbc TypeInfoCache.getDisplaySize()</a>
+ */
+class TypeDisplaySizeTest {
+
+	@Test
+	void booleanDisplaySize() {
+		// PostgreSQL returns 1 for BOOL
+		assertEquals(1, TypeDisplaySize.getDisplaySize(FireboltDataType.BOOLEAN, 0, 0));
+	}
+
+	@Test
+	void uint8DisplaySize() {
+		// UInt8 is used internally for boolean
+		assertEquals(1, TypeDisplaySize.getDisplaySize(FireboltDataType.U_INT_8, 0, 0));
+	}
+
+	@Test
+	void integerDisplaySize() {
+		// PostgreSQL INT4 -> 11 (-2147483648 to +2147483647)
+		assertEquals(11, TypeDisplaySize.getDisplaySize(FireboltDataType.INTEGER, 0, 0));
+	}
+
+	@Test
+	void bigIntDisplaySize() {
+		// PostgreSQL INT8 -> 20
+		assertEquals(20, TypeDisplaySize.getDisplaySize(FireboltDataType.BIG_INT, 0, 0));
+	}
+
+	@Test
+	void bigInt64DisplaySize() {
+		// Legacy type, same as BIG_INT
+		assertEquals(20, TypeDisplaySize.getDisplaySize(FireboltDataType.BIG_INT_64, 0, 0));
+	}
+
+	@Test
+	void unsignedBigInt64DisplaySize() {
+		// Legacy type, same as BIG_INT
+		assertEquals(20, TypeDisplaySize.getDisplaySize(FireboltDataType.UNSIGNED_BIG_INT_64, 0, 0));
+	}
+
+	@Test
+	void realDisplaySize() {
+		// PostgreSQL FLOAT4 -> 15
+		assertEquals(15, TypeDisplaySize.getDisplaySize(FireboltDataType.REAL, 0, 0));
+	}
+
+	@Test
+	void doublePrecisionDisplaySize() {
+		// PostgreSQL FLOAT8 -> 25
+		assertEquals(25, TypeDisplaySize.getDisplaySize(FireboltDataType.DOUBLE_PRECISION, 0, 0));
+	}
+
+	@Test
+	void textWithoutPrecisionDisplaySize() {
+		// TEXT without precision returns Integer.MAX_VALUE (unlimited)
+		assertEquals(Integer.MAX_VALUE, TypeDisplaySize.getDisplaySize(FireboltDataType.TEXT, 0, 0));
+		assertEquals(Integer.MAX_VALUE, TypeDisplaySize.getDisplaySize(FireboltDataType.TEXT, -1, 0));
+	}
+
+	@Test
+	void textWithPrecisionDisplaySize() {
+		// VARCHAR(n) returns n
+		assertEquals(100, TypeDisplaySize.getDisplaySize(FireboltDataType.TEXT, 100, 0));
+		assertEquals(255, TypeDisplaySize.getDisplaySize(FireboltDataType.TEXT, 255, 0));
+	}
+
+	@Test
+	void dateDisplaySize() {
+		// PostgreSQL DATE -> 13
+		assertEquals(13, TypeDisplaySize.getDisplaySize(FireboltDataType.DATE, 0, 0));
+	}
+
+	@Test
+	void date32DisplaySize() {
+		// Legacy type, same as DATE
+		assertEquals(13, TypeDisplaySize.getDisplaySize(FireboltDataType.DATE_32, 0, 0));
+	}
+
+	@Test
+	void timestampDisplaySize() {
+		// TIMESTAMP without time zone: YYYY-MM-DD HH:MM:SS.ffffff -> 26
+		assertEquals(26, TypeDisplaySize.getDisplaySize(FireboltDataType.TIMESTAMP, 0, 0));
+	}
+
+	@Test
+	void dateTime64DisplaySize() {
+		// Legacy type, same as TIMESTAMP
+		assertEquals(26, TypeDisplaySize.getDisplaySize(FireboltDataType.DATE_TIME_64, 0, 0));
+	}
+
+	@Test
+	void timestampWithTimezoneDisplaySize() {
+		// TIMESTAMP with time zone: adds +HH:MM -> 32
+		assertEquals(32, TypeDisplaySize.getDisplaySize(FireboltDataType.TIMESTAMP_WITH_TIMEZONE, 0, 0));
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"10, 2, 12",  // sign + 10 digits + decimal point = 12
+			"5, 0, 6",    // sign + 5 digits + no decimal = 6
+			"38, 10, 40"  // sign + 38 digits + decimal point = 40
+	})
+	void numericWithPrecisionDisplaySize(int precision, int scale, int expectedDisplaySize) {
+		assertEquals(expectedDisplaySize, TypeDisplaySize.getDisplaySize(FireboltDataType.NUMERIC, precision, scale));
+	}
+
+	@Test
+	void numericWithoutPrecisionDisplaySize() {
+		// PostgreSQL returns 131089 for unbounded NUMERIC
+		assertEquals(131089, TypeDisplaySize.getDisplaySize(FireboltDataType.NUMERIC, 0, 0));
+	}
+
+	@Test
+	void byteaDisplaySize() {
+		// BYTEA is unlimited
+		assertEquals(Integer.MAX_VALUE, TypeDisplaySize.getDisplaySize(FireboltDataType.BYTEA, 0, 0));
+	}
+
+	@Test
+	void arrayDisplaySize() {
+		// ARRAY is unlimited
+		assertEquals(Integer.MAX_VALUE, TypeDisplaySize.getDisplaySize(FireboltDataType.ARRAY, 0, 0));
+	}
+
+	@Test
+	void tupleDisplaySize() {
+		// TUPLE is unlimited
+		assertEquals(Integer.MAX_VALUE, TypeDisplaySize.getDisplaySize(FireboltDataType.TUPLE, 0, 0));
+	}
+
+	@Test
+	void structDisplaySize() {
+		// STRUCT is unlimited
+		assertEquals(Integer.MAX_VALUE, TypeDisplaySize.getDisplaySize(FireboltDataType.STRUCT, 0, 0));
+	}
+
+	@Test
+	void jsonDisplaySize() {
+		// JSON is unlimited
+		assertEquals(Integer.MAX_VALUE, TypeDisplaySize.getDisplaySize(FireboltDataType.JSON, 0, 0));
+	}
+
+	@Test
+	void geographyDisplaySize() {
+		// GEOGRAPHY is unlimited
+		assertEquals(Integer.MAX_VALUE, TypeDisplaySize.getDisplaySize(FireboltDataType.GEOGRAPHY, 0, 0));
+	}
+
+	@Test
+	void nothingDisplaySize() {
+		// NULL type returns unlimited
+		assertEquals(Integer.MAX_VALUE, TypeDisplaySize.getDisplaySize(FireboltDataType.NOTHING, 0, 0));
+	}
+
+	@Test
+	void unknownDisplaySize() {
+		// Unknown type returns unlimited
+		assertEquals(Integer.MAX_VALUE, TypeDisplaySize.getDisplaySize(FireboltDataType.UNKNOWN, 0, 0));
+	}
+}


### PR DESCRIPTION
**Background**

FB-762: getColumnDisplaySize() was hardcoded to return 80 for all column types, causing BI tools like Sisense to truncate TEXT column values.

**Summary**

Implemented proper display size calculation for all Firebolt data types, following the PostgreSQL JDBC driver approach:

Created new TypeDisplaySize utility class that computes display sizes based on data type For unlimited types (TEXT, BYTEA, ARRAY, STRUCT, JSON, GEOGRAPHY), returns Integer.MAX_VALUE For numeric types, returns PostgreSQL-compatible values (e.g., INTEGER → 11, BIGINT → 20) For date/time types, returns format-based sizes (DATE → 13, TIMESTAMP → 26, TIMESTAMPTZ → 32) For NUMERIC with precision, returns 1 + precision + (scale > 0 ? 1 : 0) Modified FireboltResultSetMetaData.getColumnDisplaySize() to delegate to the new utility Display size reference:

Type	Display Size
BOOLEAN	1
INTEGER	11
BIGINT	20
REAL	15
DOUBLE PRECISION	25
TEXT (unbounded)	Integer.MAX_VALUE
DATE	13
TIMESTAMP	26
TIMESTAMPTZ	32
NUMERIC(p,s)	1 + p + (s>0 ? 1 : 0)
BYTEA/ARRAY/STRUCT/JSON/GEOGRAPHY	Integer.MAX_VALUE

**Test Plan**

Added TypeDisplaySizeTest with comprehensive coverage for all data types Updated FireboltResultSetMetaDataTest to verify correct delegation and values All existing tests pass