### PR TITLE
ci(release): add opt-in skip_pre_release_tests input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,14 @@ on:
       tag_name:
         description: 'Tag name to publish'
         required: true
+      skip_pre_release_tests:
+        description: 'Skip the pre-release integration test gate. Use only when the gate is red for infra reasons unrelated to this release (e.g. staging/Core provisioning down) and the release carries unit-tested changes only.'
+        type: boolean
+        default: false
 
 jobs:
   pre-release-testing:
+    if: ${{ !inputs.skip_pre_release_tests }}
     uses: ./.github/workflows/pre-release-test.yml
     secrets:
       FIREBOLT_STG_USERNAME: ${{ secrets.FIREBOLT_STG_USERNAME }}
@@ -20,6 +25,9 @@ jobs:
 
   bump-version:
     needs: pre-release-testing
+    # Proceed when the gate passed, or when it was intentionally skipped via
+    # skip_pre_release_tests. A real failure/cancellation still halts the release.
+    if: ${{ always() && (needs.pre-release-testing.result == 'success' || needs.pre-release-testing.result == 'skipped') }}
     runs-on: ubuntu-latest
     env:
       newVersion: ${{ github.event.inputs.tag_name }}


### PR DESCRIPTION
## Summary

Adds an opt-in `skip_pre_release_tests` boolean input to the release workflow.

The pre-release integration gate (`pre-release-test.yml` → cloud + Core staging suites) periodically goes red for infra reasons unrelated to a release — staging/Core provisioning down, startup timeouts. Blocking a unit-tested release on that is incorrect, and the current workaround (hand-removing the `needs:` gate per release, then reverting — see the recent decouple + revert on master) is error-prone.

When `skip_pre_release_tests=true`, the `pre-release-testing` job is skipped and `bump-version` proceeds. A genuine gate **failure/cancellation** still halts the release (`bump-version` only runs on `success` or `skipped`). Default is `false`, so normal releases are unchanged and the gate stays on.

## Test Plan
- YAML validated.
- Immediate use: releasing `v3.10.1` (unit-tested resultset fix #751) with `skip_pre_release_tests=true`, since the staging suite is currently red on infra grounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
