### PR TITLE
ci(release): publish to Maven Central via the Central Portal OSSRH staging API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,8 +103,13 @@ jobs:
         draft: false
         tag_name: ${{ github.event.inputs.tag_name }}
 
-    - name: Publish and release to Sonatype
-      run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+    - name: Publish to Maven Central (Central Portal via OSSRH staging API)
+      # The legacy Nexus flow (publishToSonatype closeAndReleaseSonatypeStagingRepository)
+      # relies on the staging-profile API, which the Central Portal OSSRH shim does not
+      # expose -> "Failed to find staging profile for package group: io.firebolt". Instead
+      # deploy to the OSSRH staging deploy endpoint (auto-creates the namespace's default
+      # repository), then promote it into the Central Publisher Portal.
+      run: ./gradlew publishMavenPublicationToMavenRepository manualUploadToMavenCentral
       env:
         MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
         MAVEN_REPO_PASSWORD: ${{ secrets.MAVEN_REPO_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -282,14 +282,9 @@ publishing {
                 }
                 developers {
                     developer {
-                        id = "goprean"
-                        name = "George Oprean"
-                        email = "george.oprean@firebolt.io"
-                    }
-                    developer {
-                        id = "bogdan.truta"
-                        name = "Bogdan Truta"
-                        email = "bogdan.truta@firebolt.io"
+                        id = "moshap"
+                        name = "Mosha Pasumansky"
+                        email = "moshap@firebolt.io"
                     }
                 }
                 scm {


### PR DESCRIPTION
The release publishes nothing to Central: the publish step used `publishToSonatype closeAndReleaseSonatypeStagingRepository`, whose legacy Nexus staging-profile API the Central Portal OSSRH shim doesn't expose (`Failed to find staging profile for package group: io.firebolt`). Switch to the Portal flow already configured in build.gradle: `publishMavenPublicationToMavenRepository` (deploy → namespace default repository) + `manualUploadToMavenCentral` (promote into the Central Publisher Portal). Also sets the POM developer to the current maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)