### PR TITLE
ci(release): auto-publish deployments to Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -340,7 +340,9 @@ task manualUploadToMavenCentral {
 
         def mavenHost = "https://ossrh-staging-api.central.sonatype.com"
         def namespace = "io.firebolt"
-        def apiUrl = "${mavenHost}/manual/upload/defaultRepository/${namespace}"
+        // publishing_type defaults to user_managed (deployment waits for a manual Publish in
+        // the Central Portal UI); automatic validates and releases to Central without that step.
+        def apiUrl = "${mavenHost}/manual/upload/defaultRepository/${namespace}?publishing_type=automatic"
 
         println "Calling API: $apiUrl"
 


### PR DESCRIPTION
manualUploadToMavenCentral defaulted to user_managed publishing, so 3.10.1 landed in the Portal but never released to Central. Set publishing_type=automatic. 🤖 Generated with [Claude Code](https://claude.com/claude-code)